### PR TITLE
Add silky smooth way to install anchore-cli on Mac OS.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ You can use our pre-built binary for Mac:
 .. code::
 
     cd /usr/local/bin
-    curl -O https://raw.githubusercontent.com/anchore/anchore-cli/master/scripts/macos-bin/anchore-cli
+    curl -LJO https://raw.githubusercontent.com/anchore/anchore-cli/master/scripts/macos-bin/anchore-cli
     chmod 755 anchore-cli
 
 Or use pip if you already have it set up on your Mac:

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,24 @@ Installing Anchore CLI on Debian and Ubuntu
     apt-get install python-pip
     pip install anchorecli 
 
+Installing Anchore CLI on Mac OS / OS X
+===========================================
+
+You can use our pre-built binary for Mac:
+
+.. code::
+
+    cd /usr/local/bin
+    curl -O https://raw.githubusercontent.com/anchore/anchore-cli/master/scripts/macos-bin/anchore-cli
+    chmod 755 anchore-cli
+
+Or use pip if you already have it set up on your Mac:
+
+.. code::
+
+    pip install anchorecli
+
+
 Configuring the Anchore CLI
 ===========================
 

--- a/scripts/make-macos-bin.sh
+++ b/scripts/make-macos-bin.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -x
+set -e
+
+echo "Check we're on Mac OS before continuing..."
+uname -s | grep Darwin
+
+export VIRTUALENV_DIR="anchore_virtualenv"
+export DIST_PATH="macos-bin"
+
+# Install pip if not installed
+if ! which pip > /dev/null; then
+    sudo easy_install pip
+fi
+
+# Install virtualenv if not installed
+if ! which virtualenv > /dev/null; then
+    sudo easy_install virtualenv
+fi
+
+# Create a new python virtual environment
+virtualenv $VIRTUALENV_DIR
+
+# Install required packages into the virtual environment
+$VIRTUALENV_DIR/bin/pip install pyinstaller anchorecli
+
+# Compile anchore-cli script into distributable bundle
+$VIRTUALENV_DIR/bin/pyinstaller --log-level=ERROR --noconfirm --onefile --distpath $DIST_PATH $VIRTUALENV_DIR/bin/anchore-cli
+
+# If you want to create an archive
+# if [ -f anchore-cli-macos.zip ]; then
+#     rm anchore-cli-macos.zip
+# fi
+# zip -r -X anchore-cli-macos.zip $DIST_PATH
+
+# Cleanup
+rm -rf $VIRTUALENV_DIR build
+rm anchore-cli.spec


### PR DESCRIPTION
Includes build script, binary build for 0.1.0, and updated install instructions.