### PR TITLE
Allow API Version to be explicitly specified in env var or cmd options

### DIFF
--- a/anchorecli/cli/__init__.py
+++ b/anchorecli/cli/__init__.py
@@ -16,13 +16,14 @@ import anchorecli.clients
 @click.option('--u', help='Username (or use environment variable ANCHORE_CLI_USER)')
 @click.option('--p', help='Password (or use environment variable ANCHORE_CLI_PASS)')
 @click.option('--url', help='Service URL (or use environment variable ANCHORE_CLI_URL)')
+@click.option('--api-version', help='Explicitly specify the API version to skip checking. Useful when swagger endpoint is inaccessible')
 @click.option('--insecure', is_flag=True, help='Skip SSL cert checks (or use environment variable ANCHORE_CLI_SSL_VERIFY=<y/n>)')
 @click.option('--json', is_flag=True, help='Output raw API JSON')
 
 @click.version_option(version=version.version)
 @click.pass_context
 #@extended_help_option(extended_help="extended help")
-def main_entry(ctx, debug, u, p, url, insecure, json):
+def main_entry(ctx, debug, u, p, url, api_version, insecure, json):
     if debug:
         logging.basicConfig(level=logging.DEBUG)
 
@@ -30,6 +31,7 @@ def main_entry(ctx, debug, u, p, url, insecure, json):
         'u': u,
         'p': p,
         'url': url,
+        'api-version': api_version,
         'insecure': insecure,
         'json': json,
         'debug': debug

--- a/anchorecli/cli/evaluate.py
+++ b/anchorecli/cli/evaluate.py
@@ -47,7 +47,7 @@ def check(input_image, show_history, detail, tag, policy):
             ecode = anchorecli.cli.utils.get_ecode(ret)
             if ret['success']:
                 print(anchorecli.cli.utils.format_output(config, 'evaluate_check', {'detail': detail, 'history': show_history, 'tag': thetag}, ret['payload']))
-                ecode = anchorecli.cli.utils.get_eval_ecode(ret['payload'], imageDigest)
+                ecode = anchorecli.cli.utils.get_eval_ecode(ret['payload'], anchorecli.cli.utils.unquote_plus(imageDigest))
             else:
                 raise Exception(json.dumps(ret['error'], indent=4))
         else:

--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -26,6 +26,7 @@ def setup_config(cli_opts):
         'user':None,
         'pass':None,
         'url':"http://localhost:8228/v1",
+        'api-version': None,
         'ssl_verify':True,
         'jsonmode':False,
         'debug':False,
@@ -50,7 +51,7 @@ def setup_config(cli_opts):
                         raise Exception("invalid credentials file format")
 
                     default_creds = ydata.get('default', {})
-                    for e in ['ANCHORE_CLI_USER', 'ANCHORE_CLI_PASS', 'ANCHORE_CLI_URL', 'ANCHORE_CLI_SSL_VERIFY']:
+                    for e in ['ANCHORE_CLI_USER', 'ANCHORE_CLI_PASS', 'ANCHORE_CLI_URL', 'ANCHORE_CLI_API_VERSION', 'ANCHORE_CLI_SSL_VERIFY']:
                         if e in default_creds:
                             settings[e] = default_creds[e]
                 except Exception as err:
@@ -61,7 +62,7 @@ def setup_config(cli_opts):
     
     # load environment if present
     try:
-        for e in ['ANCHORE_CLI_USER', 'ANCHORE_CLI_PASS', 'ANCHORE_CLI_URL', 'ANCHORE_CLI_SSL_VERIFY', 'ANCHORE_CLI_JSON', 'ANCHORE_CLI_DEBUG']:
+        for e in ['ANCHORE_CLI_USER', 'ANCHORE_CLI_PASS', 'ANCHORE_CLI_URL', 'ANCHORE_CLI_API_VERSION', 'ANCHORE_CLI_SSL_VERIFY', 'ANCHORE_CLI_JSON', 'ANCHORE_CLI_DEBUG']:
             if e in os.environ:
                 settings[e] = os.environ[e]
     except Exception as err:
@@ -77,6 +78,9 @@ def setup_config(cli_opts):
 
         if cli_opts['url']:
             settings['ANCHORE_CLI_URL'] = cli_opts['url']
+
+        if cli_opts['api-version']:
+            settings['ANCHORE_CLI_API_VERSION'] = cli_opts['api-version']
 
         if cli_opts['insecure']:
             settings['ANCHORE_CLI_SSL_VERIFY'] = "n"
@@ -98,6 +102,8 @@ def setup_config(cli_opts):
         if 'ANCHORE_CLI_URL' in settings:
             ret['url'] = settings['ANCHORE_CLI_URL']
 
+        if 'ANCHORE_CLI_API_VERSION' in settings:
+            ret['api-version'] = settings['ANCHORE_CLI_API_VERSION']
         if 'ANCHORE_CLI_SSL_VERIFY' in settings:
             if settings['ANCHORE_CLI_SSL_VERIFY'].lower() == 'n':
                 ret['ssl_verify'] = False

--- a/anchorecli/clients/apiexternal.py
+++ b/anchorecli/clients/apiexternal.py
@@ -163,6 +163,8 @@ def detect_api_version(config):
     :param config:
     :return: tuple of ints
     """
+    if config['api-version']:
+        return tuple([int(x) for x in config['api-version'].split('.')])
 
     url = urlparse(config['url'])
     url = urlunparse((url.scheme, url.netloc, '/swagger.json', url.params, url.query, url.fragment))


### PR DESCRIPTION
We have an Anchore engine where access to the swagger.json endpoint is restricted and hence the detection of api versions fails. This results in a call to get_image that presumes an older api and sends a payload on the get request resulting in a 403 from CloudFront in this case. 

To remedy this, I have added an explicit option for specifying the api version either via environment variable or cli option. When this has been specified, the version check will be skipped.

Hopefully other people will find this useful.