### PR TITLE
Improve Debian and Ubuntu documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,8 @@ Installing Anchore CLI on Debian and Ubuntu
 
     apt-get update 
     apt-get install python-pip
-    pip install anchorecli 
+    pip install anchorecli
+    Note make sure ~/.local/bin is part of your PATH or just export it directly: export PATH="$HOME/.local/bin/:$PATH"
 
 Installing Anchore CLI on Mac OS / OS X
 ===========================================


### PR DESCRIPTION
Note many versions of Debian and Ubuntu still not adding ~/.local/bin to $PATH, therefore pip install anchorecli will succeed but the command won't be available for the user. See https://bugs.launchpad.net/ubuntu/+source/bash/+bug/1588562 and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=820856

Mention in the documentation about double checking ~/.local/bin being exported as part of the PATH  in .bash_profile and/or .profile or simply exporting it before executing anchore-cli

CC: @nurmi