### PR TITLE
Use os.path.expanduser for cross-platform home-finding

### DIFF
--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -39,7 +39,7 @@ def setup_config(cli_opts):
 
     # load up credentials file if present
     try:
-        home = os.environ.get('HOME', None)
+        home = os.path.expanduser('~')
         credential_file = os.path.join(home, '.anchore', 'credentials.yaml')
         if os.path.exists(credential_file):
             ydata = {}


### PR DESCRIPTION
Thanks for the great tool!

I recently was kicking the tires on some windows containers where the AD account I was using didn't set `%HOME%` (probably `ROAMING_PROFILE` or some such). Anyhow, `os.path.expanduser` is more robust at finding these oddities, and while I've worked around it, it would be nice if others did have the same frustrations.