### PR TITLE
Introduce test harness, cleanup from linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,52 @@ var_2: &attach_workspace
 
 # Start circleci configuration
 version: 2.1
+commands:
+  run_tox_tests:
+    description: Run tox tests
+    parameters:
+      environment:
+        type: string
+    steps:
+    - checkout
+    - restore_cache:
+        keys:
+        - v1-dependencies-{{ .Branch }}-{{ checksum "requirements.txt" }}
+    - run:
+        name: install dependencies
+        command: |
+          sudo pip install --upgrade pip
+          sudo pip install --upgrade tox
+    - run:
+        name: run tests
+        command: |
+          tox << parameters.environment >> | tee tox.log
+    - save_cache:
+        paths:
+          - ~/project/.tox
+        key: v1-dependencies-{{ .Branch }}-{{ checksum "requirements.txt" }}
+    - store_artifacts:
+        path: tox.log
+
 jobs:
+  linting:
+    docker:
+    - image: circleci/python:3.6
+    steps:
+    - run_tox_tests:
+        environment: "-e flake8"
+  unit_tests_py27:
+    docker:
+    - image: circleci/python:2.7
+    steps:
+    - run_tox_tests:
+        environment: "-e py27"
+  unit_tests_py36:
+    docker:
+    - image: circleci/python:3.6
+    steps:
+    - run_tox_tests:
+        environment: "-e py36"
   build:
     docker:
       - image: docker:stable-git
@@ -106,6 +151,9 @@ jobs:
 workflows:
   default_workflow:
     jobs:
+      - unit_tests_py27
+      - unit_tests_py36
+      - linting
       - build:
           filters:
             branches:

--- a/anchorecli/cli/__init__.py
+++ b/anchorecli/cli/__init__.py
@@ -1,7 +1,4 @@
-import os
 import click
-import subprocess
-import sys
 import logging
 
 from . import image, policy, evaluate, subscription, registry, system, utils, repo, event, query, account, archives
@@ -9,7 +6,6 @@ from . import image, policy, evaluate, subscription, registry, system, utils, re
 from anchorecli import version
 import anchorecli.clients
 
-#from anchoreservice.subsys import logger
 
 @click.group()
 @click.option('--debug', is_flag=True, help='Debug output to stderr')
@@ -23,7 +19,6 @@ import anchorecli.clients
 @click.option('--as-account', help='Set account context for the command to another account than the one the user belongs to. Subject to authz', default=None)
 @click.version_option(version=version.version)
 @click.pass_context
-#@extended_help_option(extended_help="extended help")
 def main_entry(ctx, debug, u, p, url, hub_url, api_version, insecure, json, as_account):
     if debug:
         logging.basicConfig(level=logging.DEBUG)
@@ -43,8 +38,9 @@ def main_entry(ctx, debug, u, p, url, hub_url, api_version, insecure, json, as_a
     config = utils.setup_config(cli_opts)
     if config['debug']:
         logging.basicConfig(level=logging.DEBUG)
-        
+
     ctx.obj = config
+
 
 main_entry.add_command(image.image)
 main_entry.add_command(evaluate.evaluate)

--- a/anchorecli/cli/__init__.py
+++ b/anchorecli/cli/__init__.py
@@ -4,7 +4,7 @@ import logging
 from . import image, policy, evaluate, subscription, registry, system, utils, repo, event, query, account, archives
 
 from anchorecli import version
-import anchorecli.clients
+import anchorecli.clients # noqa
 
 
 @click.group()

--- a/anchorecli/cli/account.py
+++ b/anchorecli/cli/account.py
@@ -1,5 +1,4 @@
 import sys
-import os
 import re
 import json
 import click
@@ -217,7 +216,6 @@ def disable(account_name):
 
 # user suboperation
 
-whoami = {}
 @account.group(name="user", short_help="Account user operations")
 def user():
     global config, whoami
@@ -236,7 +234,7 @@ def user_add(user_name, user_password, account):
 
     if not account:
         account = whoami.get('account', {}).get('name', None)
-        
+
     ecode = 0
 
     try:
@@ -271,7 +269,7 @@ def user_delete(user_name, account):
 
     if not account:
         account = whoami.get('account', {}).get('name', None)
-        
+
     ecode = 0
 
     try:
@@ -302,7 +300,7 @@ def user_get(user_name, account):
 
     if not account:
         account = whoami.get('account', {}).get('name', None)
-        
+
     ecode = 0
 
     try:
@@ -332,7 +330,7 @@ def user_list(account):
 
     if not account:
         account = whoami.get('account', {}).get('name', None)
-        
+
     ecode = 0
 
     try:
@@ -384,5 +382,5 @@ def user_setpassword(user_password, username, account):
             ecode = 2
 
     anchorecli.cli.utils.doexit(ecode)
-    
+
 

--- a/anchorecli/cli/image.py
+++ b/anchorecli/cli/image.py
@@ -1,6 +1,4 @@
 import sys
-import os
-import re
 import json
 import click
 import logging
@@ -122,7 +120,7 @@ def add(input_image, force, dockerfile, annotation, noautosubscribe):
                             annotations[k] = v
                         else:
                             raise Exception("found null in key or value")
-                    except Exception as err:
+                    except Exception:
                         raise Exception("annotation format error - annotations must be of the form (--annotation key=value), found: {}".format(a))
 
             ret = anchorecli.clients.apiexternal.add_image(config, tag=input_image, force=force, dockerfile=dockerfile_contents, annotations=annotations, autosubscribe=autosubscribe)
@@ -173,7 +171,7 @@ def get(input_image, show_history):
     INPUT_IMAGE: Input image can be in the following formats: Image Digest, ImageID or registry/repo:tag
     """
     ecode = 0
-    
+
     try:
         itype = anchorecli.cli.utils.discover_inputimage_format(config, input_image)
         image = input_image
@@ -233,7 +231,7 @@ def query_content(input_image, content_type):
     """
     INPUT_IMAGE: Input image can be in the following formats: Image Digest, ImageID or registry/repo:tag
 
-    CONTENT_TYPE: The content type can be one of the following types: 
+    CONTENT_TYPE: The content type can be one of the following types:
 
       - os: Operating System Packages
 
@@ -244,7 +242,7 @@ def query_content(input_image, content_type):
       - files: Files
     """
     ecode = 0
-    
+
     try:
         itype, image, imageDigest = anchorecli.cli.utils.discover_inputimage(config, input_image)
         _logger.debug("discovery from input: " + str(itype) + " : " + str(image) + " : " + str(imageDigest))
@@ -281,7 +279,7 @@ def query_metadata(input_image, metadata_type):
 
     """
     ecode = 0
-    
+
     try:
         itype, image, imageDigest = anchorecli.cli.utils.discover_inputimage(config, input_image)
         _logger.debug("discovery from input: " + str(itype) + " : " + str(image) + " : " + str(imageDigest))
@@ -318,8 +316,8 @@ def query_metadata(input_image, metadata_type):
 def query_vuln(input_image, vuln_type, vendor_only):
     """
     INPUT_IMAGE: Input image can be in the following formats: Image Digest, ImageID or registry/repo:tag
-    
-    VULN_TYPE: VULN_TYPE: Vulnerability type can be one of the following types: 
+
+    VULN_TYPE: VULN_TYPE: Vulnerability type can be one of the following types:
 
       - os: CVE/distro vulnerabilities against operating system packages
     """
@@ -357,7 +355,7 @@ def delete(input_image, force):
     INPUT_IMAGE: Input image can be in the following formats: Image Digest, ImageID or registry/repo:tag
     """
     ecode = 0
-    
+
     try:
         itype, image, imageDigest = anchorecli.cli.utils.discover_inputimage(config, input_image)
 

--- a/anchorecli/cli/query.py
+++ b/anchorecli/cli/query.py
@@ -1,6 +1,4 @@
 import sys
-import os
-import re
 import json
 import click
 import logging

--- a/anchorecli/cli/registry.py
+++ b/anchorecli/cli/registry.py
@@ -1,5 +1,4 @@
 import sys
-import os
 import re
 import json
 import click

--- a/anchorecli/cli/repo.py
+++ b/anchorecli/cli/repo.py
@@ -1,6 +1,4 @@
 import sys
-import os
-import re
 import json
 import click
 import logging

--- a/anchorecli/cli/subscription.py
+++ b/anchorecli/cli/subscription.py
@@ -1,6 +1,4 @@
 import sys
-import os
-import re
 import json
 import click
 

--- a/anchorecli/cli/system.py
+++ b/anchorecli/cli/system.py
@@ -1,6 +1,4 @@
 import sys
-import os
-import re
 import json
 import time
 import click
@@ -71,8 +69,8 @@ def wait(timeout, interval, feedsready, servicesready):
     """
     Wait for an image to go to analyzed or analysis_failed status with a specific timeout
 
-    :param timeout: 
-    :param interval: 
+    :param timeout:
+    :param interval:
     :param feedsready:
     :return:
     """
@@ -88,7 +86,7 @@ def wait(timeout, interval, feedsready, servicesready):
             try:
                 anchorecli.cli.utils.check_access(config)
                 _logger.debug("check access success")
-                break;
+                break
             except Exception as err:
                 _logger.debug("check access failed, trying again")
             time.sleep(interval)
@@ -127,7 +125,7 @@ def wait(timeout, interval, feedsready, servicesready):
 
                     if False not in all_up.values():
                         _logger.debug("full set of available engine services detected")
-                        break;
+                        break
                     else:
                         _logger.debug("service set not yet available {}".format(all_up))
                 elif ret.get('httpcode', 500) in [401]:

--- a/anchorecli/cli/system.py
+++ b/anchorecli/cli/system.py
@@ -87,7 +87,7 @@ def wait(timeout, interval, feedsready, servicesready):
                 anchorecli.cli.utils.check_access(config)
                 _logger.debug("check access success")
                 break
-            except Exception as err:
+            except Exception:
                 _logger.debug("check access failed, trying again")
             time.sleep(interval)
         else:
@@ -235,7 +235,7 @@ def feedsync(flush):
             except NameError:
                 pass
             answer = input("Really perform a manual feed data sync/flush? (y/N)")
-        except Exception as err:
+        except Exception:
             answer = "n"
 
         if 'y' == answer.lower():

--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -186,7 +186,7 @@ def format_error_output(config, op, params, payload):
         if not obuf:
             raise Exception("not JSON output could be parsed from error response")
         #obuf = obuf + "\n"
-    except Exception as err:
+    except Exception:
         obuf = str(payload)
 
     # operation-specific output postfixes
@@ -202,7 +202,8 @@ def format_output(config, op, params, payload):
     if config['jsonmode']:
         try:
             ret = json.dumps(payload, indent=4, sort_keys=True)
-        except:
+        # XXX catch json exception explicitly here
+        except Exception:
             ret = json.dumps({'payload': str(payload)}, indent=4, sort_keys=True)
         return(ret)
 

--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -67,6 +67,7 @@ def setup_config(cli_opts):
         for e in ['ANCHORE_CLI_USER', 'ANCHORE_CLI_PASS', 'ANCHORE_CLI_URL', 'ANCHORE_CLI_HUB_URL', 'ANCHORE_CLI_API_VERSION', 'ANCHORE_CLI_SSL_VERIFY', 'ANCHORE_CLI_JSON', 'ANCHORE_CLI_DEBUG', 'ANCHORE_CLI_ACCOUNT']:
             if e in os.environ:
                 settings[e] = os.environ[e]
+    # XXX no need
     except Exception as err:
         raise err
 
@@ -99,6 +100,7 @@ def setup_config(cli_opts):
         if cli_opts.get('as_account') is not None:
             settings['ANCHORE_CLI_ACCOUNT'] = cli_opts['as_account']
 
+    # XXX no need
     except Exception as err:
         raise err
 
@@ -126,6 +128,7 @@ def setup_config(cli_opts):
         if 'ANCHORE_CLI_ACCOUNT' in settings:
             ret['as_account'] = settings['ANCHORE_CLI_ACCOUNT']
 
+    # XXX no need
     except Exception as err:
         raise err
 
@@ -358,7 +361,7 @@ def format_output(config, op, params, payload):
                 elif params['query_type'] in ['manifest', 'dockerfile', 'docker_history']:
                     try:
                         obuf = base64.b64decode(payload.get('metadata', "")).decode('utf-8')
-                    except Exception as err:
+                    except Exception:
                         obuf = ""
                 else:
                     try:
@@ -719,6 +722,7 @@ def format_output(config, op, params, payload):
                 obuf = obuf + "Engine Code Version: {}\n".format(code_version)
 
                 ret = obuf
+            # XXX no need
             except Exception as err:
                 raise err
         elif op == 'event_delete':
@@ -756,6 +760,7 @@ def format_output(config, op, params, payload):
                             last_sync = "pending"
                         t.add_row([feed, gel.get('name', "N/A"), last_sync, gel.get('record_count', "N/A")])
                 ret = t.get_string(sortby='Feed')+"\n"
+            # XXX no need
             except Exception as err:
                 raise err
         elif op in ['system_feeds_flush']:
@@ -950,7 +955,8 @@ def format_output(config, op, params, payload):
         print("WARNING: failed to format output (returning raw output) - exception: " + str(err))
         try:
             ret = json.dumps(payload, indent=4, sort_keys=True)
-        except:
+        # XXX catch json errors here
+        except Exception:
             ret = str(payload)
     return(ret)
 
@@ -1001,6 +1007,7 @@ def _format_gates(payload, all=False):
         else:
             return  'No policy spec to parse'
 
+    # XXX no need
     except Exception as err:
         raise err
 
@@ -1028,6 +1035,7 @@ def _format_triggers(payload, gate, all=False):
         else:
             return 'No policy spec to parse'
 
+    # XXX no need
     except Exception as err:
         raise err
 
@@ -1057,6 +1065,7 @@ def _format_trigger_params(payload, gate, trigger, all=False):
         else:
             return 'No policy spec to parse'
 
+    # XXX no need
     except Exception as err:
         raise err
 
@@ -1073,7 +1082,7 @@ def get_eval_ecode(evaldata, imageDigest):
             ret = 1
         else:
             raise Exception("got unknown eval status result: " + str(status))
-    except Exception as err:
+    except Exception:
         ret = 2
     return(ret)
 
@@ -1136,7 +1145,7 @@ def discover_inputimage(config, input_string):
         patt = re.match("(.*@|^)(local:.*)", digest)
         if patt:
             return("imageDigest", input_string, input_string)
-    except Exception as err:
+    except Exception:
         pass
 
     urldigest = None
@@ -1151,11 +1160,11 @@ def discover_inputimage(config, input_string):
                     if input_string == image_detail['imageId']:
                         ret_type = "imageid"
                         break
-            except Exception as err:
+            except Exception:
                 pass
         else:
             pass
-    except Exception as err:
+    except Exception:
         urldigest = None
 
     return(ret_type, input_string, urldigest)

--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -6,14 +6,13 @@ import json
 import yaml
 import logging
 import dateutil.parser
-import struct
 import textwrap
 import base64
 
 try:
-    from urllib.parse import quote_plus,unquote_plus
-except:
-    from urllib import quote_plus,unquote_plus
+    from urllib.parse import quote_plus, unquote_plus
+except ImportError:
+    from urllib import quote_plus, unquote_plus
 
 from prettytable import PrettyTable, PLAIN_COLUMNS, ALL
 from collections import OrderedDict
@@ -62,7 +61,7 @@ def setup_config(cli_opts):
 
     except Exception as err:
         raise Exception("error while processing credentials file, please check format and read permissions - exception: " + str(err))
-    
+
     # load environment if present
     try:
         for e in ['ANCHORE_CLI_USER', 'ANCHORE_CLI_PASS', 'ANCHORE_CLI_URL', 'ANCHORE_CLI_HUB_URL', 'ANCHORE_CLI_API_VERSION', 'ANCHORE_CLI_SSL_VERIFY', 'ANCHORE_CLI_JSON', 'ANCHORE_CLI_DEBUG', 'ANCHORE_CLI_ACCOUNT']:
@@ -93,7 +92,7 @@ def setup_config(cli_opts):
 
         if cli_opts['json']:
             settings['ANCHORE_CLI_JSON'] = "y"
-        
+
         if cli_opts['debug']:
             settings['ANCHORE_CLI_DEBUG'] = "y"
 
@@ -174,7 +173,7 @@ def format_error_output(config, op, params, payload):
 
     obuf = ""
     try:
-        outdict = OrderedDict()    
+        outdict = OrderedDict()
         if 'message' in errdata:
             outdict['Error'] = str(errdata['message'])
         if 'httpcode' in errdata:
@@ -197,7 +196,7 @@ def format_error_output(config, op, params, payload):
 
     ret = obuf
     return(ret)
-            
+
 
 def format_output(config, op, params, payload):
     if config['jsonmode']:
@@ -252,7 +251,7 @@ def format_output(config, op, params, payload):
                     if dockerfile:
                         dockerpresent = "Present"
 
-                    imageId = image_detail.pop('imageId', "None") 
+                    imageId = image_detail.pop('imageId', "None")
                     fulltag = image_detail.pop('registry', "None") + "/" + image_detail.pop('repo', "None") + ":" + image_detail.pop('tag', "None")
                     #registry = image_detail.pop('registry', "None")
 
@@ -400,7 +399,7 @@ def format_output(config, op, params, payload):
                 if dockerfile:
                     dockerpresent = "Present"
 
-                imageId = image_detail.pop('imageId', "None") 
+                imageId = image_detail.pop('imageId', "None")
                 outdict['Image ID'] = str(imageId)
                 #outdict['Dockerfile'] = str(dockerpresent)
 
@@ -432,7 +431,7 @@ def format_output(config, op, params, payload):
                         obuf = obuf + k + ": " + outdict[k] + "\n"
                     obuf = obuf + "\n"
 
-            ret = obuf    
+            ret = obuf
         elif op in ['registry_add', 'registry_get', 'registry_update']:
             obuf = ""
             for registry_record in payload:
@@ -558,7 +557,7 @@ def format_output(config, op, params, payload):
             obuf = ""
 
             outdict = OrderedDict()
-            
+
             outdict['Policy Bundle ID'] = str(payload['id'])
             outdict['Name'] = str(payload['name'])
             outdict['Description'] = str(payload.get('description', payload.get('comment', "N/A")))
@@ -594,7 +593,7 @@ def format_output(config, op, params, payload):
                 pids = []
                 pid = record.get('policy_id', None)
                 if pid:
-                    pids.append(pid) 
+                    pids.append(pid)
                 pids = [str(id_to_name[x]) for x in pids + record.get('policy_ids', [])]
                 outdict['Mapping Policies'] = ",".join(pids)
                 wids = [str(id_to_name[x]) for x in record.get('whitelist_ids', [])]
@@ -660,7 +659,7 @@ def format_output(config, op, params, payload):
                                                     status_detail = "whitelisted("+eval_whitelist_detail['whitelist_name']+")"
                                             except:
                                                 status_detail = row[6]
-                                                
+
                                             newrow = [row[3], row[4], detailrow, status_detail]
                                             t.add_row(newrow)
 
@@ -680,7 +679,7 @@ def format_output(config, op, params, payload):
         elif op == 'system_status':
             try:
                 obuf = ""
-                
+
                 outlist = []
 
                 db_version = code_version = None
@@ -690,7 +689,7 @@ def format_output(config, op, params, payload):
                         service_status = "up"
                     else:
                         service_status = "down ({})".format(service_record['status_message'])
-                        
+
                     outlist.append("Service "+service_record['servicename']+" ("+service_record['hostid']+", " +service_record['base_url'] +"): " + str(service_status))
                     if not db_version:
                         try:
@@ -703,7 +702,7 @@ def format_output(config, op, params, payload):
                             code_version = service_record['service_detail']['version']
                         except:
                             pass
-                        
+
                     # override with any discovered API service that is up
                     try:
                         if service_record['servicename'] == 'apiext' and service_status == 'up':
@@ -711,7 +710,7 @@ def format_output(config, op, params, payload):
                             code_version = api_code_version
                     except:
                         pass
-                        
+
                 for k in outlist:
                     obuf = obuf + k + "\n"
                 obuf = obuf + "\n"
@@ -748,7 +747,7 @@ def format_output(config, op, params, payload):
                 header = ['Feed', 'Group', 'LastSync', 'RecordCount']
                 t = PrettyTable(header)
                 t.set_style(PLAIN_COLUMNS)
-                t.align = 'l'                        
+                t.align = 'l'
                 for el in payload:
                     feed = el.get('name', "N/A")
                     for gel in el['groups']:
@@ -799,7 +798,7 @@ def format_output(config, op, params, payload):
             header = ['Full Tag', 'Severity', 'Package', 'Package Type', 'Namespace', 'Digest']
             t = PrettyTable(header)
             t.set_style(PLAIN_COLUMNS)
-            t.align = 'l'            
+            t.align = 'l'
             for record in payload.get('images', []):
                 for tag_record in record.get('image', {}).get('tag_history', []):
                     for package_record in record.get('vulnerable_packages', []):
@@ -811,7 +810,7 @@ def format_output(config, op, params, payload):
             header = ['Full Tag', 'Package', 'Package Type', 'Digest']
             t = PrettyTable(header)
             t.set_style(PLAIN_COLUMNS)
-            t.align = 'l'            
+            t.align = 'l'
             for record in payload.get('images', []):
                 for tag_record in record.get('image', {}).get('tag_history', []):
                     for package_record in record.get('packages', []):
@@ -820,7 +819,7 @@ def format_output(config, op, params, payload):
             ret = t.get_string()
         elif op == 'account_whoami':
             outdict = OrderedDict()
-            
+
             outdict['Username'] = str(payload.get('user', {}).get('username', "N/A"))
             outdict['AccountName'] = str(payload.get('account', {}).get('name', "N/A"))
             outdict['AccountEmail'] = str(payload.get('account', {}).get('email', "N/A"))
@@ -834,7 +833,7 @@ def format_output(config, op, params, payload):
             ret = obuf
         elif op in ['account_add', 'account_get']:
             outdict = OrderedDict()
-            
+
             outdict['Name'] = str(payload.get('name', "N/A"))
             outdict['Email'] = str(payload.get('email', "N/A"))
             outdict['Type'] = str(payload.get('type', "N/A"))
@@ -851,7 +850,7 @@ def format_output(config, op, params, payload):
             header = ['Name', 'Email', 'Type', 'State', 'Created']
             t = PrettyTable(header)
             t.set_style(PLAIN_COLUMNS)
-            t.align = 'l'            
+            t.align = 'l'
             for record in payload:
                 row = [str(record.get('name', "N/A")), str(record.get('email', "N/A")), str(record.get('type', "N/A")), str(record.get('state', "N/A")), str(record.get('created_at', "N/A"))]
                 t.add_row(row)
@@ -860,7 +859,7 @@ def format_output(config, op, params, payload):
 
         elif op in ['user_add', 'user_get']:
             outdict = OrderedDict()
-            
+
             outdict['Name'] = str(payload.get('username', "N/A"))
             outdict['Type'] = str(payload.get('type', "N/A"))
             outdict['Source'] = str(payload.get('source', "N/A"))
@@ -876,11 +875,11 @@ def format_output(config, op, params, payload):
             header = ['Name', 'Type', 'Source', 'Created']
             t = PrettyTable(header)
             t.set_style(PLAIN_COLUMNS)
-            t.align = 'l'            
+            t.align = 'l'
             for record in payload:
                 row = [str(record.get('username', "N/A")), str(record.get('type', "N/A")), str(record.get('source', "N/A")), str(record.get('created_at', "N/A"))]
                 t.add_row(row)
-            ret = t.get_string(sortby='Created')+"\n"            
+            ret = t.get_string(sortby='Created')+"\n"
         elif op in ['user_setpassword']:
             ret = "Password (re)set success"
         elif op in ['delete_system_service'] or re.match(".*_delete$", op) or re.match(".*_activate$", op) or re.match(".*_deactivate$", op) or re.match(".*_enable$", op) or re.match(".*_disable$", op):
@@ -1061,7 +1060,7 @@ def _format_trigger_params(payload, gate, trigger, all=False):
     except Exception as err:
         raise err
 
-        
+
 def get_eval_ecode(evaldata, imageDigest):
     #0 aid tag 0 status
     ret = 2
@@ -1214,7 +1213,7 @@ def parse_dockerimage_string(instr):
         patt = re.match("(.*)@(.*)", remain)
         if patt:
             repo = patt.group(1)
-            digest = patt.group(2)        
+            digest = patt.group(2)
         else:
             patt = re.match("(.*):(.*)", remain)
             if patt:

--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -247,14 +247,13 @@ def format_output(config, op, params, payload):
                 for image_detail_record in image_record['image_detail']:
                     image_detail = copy.deepcopy(image_detail_record)
 
-                    dockerpresent = imageId = fulltag = registy = "None"
+                    dockerpresent = imageId = fulltag = "None"
                     dockerfile = image_detail.pop('dockerfile', None)
                     if dockerfile:
                         dockerpresent = "Present"
 
                     imageId = image_detail.pop('imageId', "None")
                     fulltag = image_detail.pop('registry', "None") + "/" + image_detail.pop('repo', "None") + ":" + image_detail.pop('tag', "None")
-                    #registry = image_detail.pop('registry', "None")
 
                     if params['full']:
                         row = [fulltag, image_record['imageDigest'], image_record['analysis_status'], imageId]

--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -250,10 +250,7 @@ def format_output(config, op, params, payload):
                 for image_detail_record in image_record['image_detail']:
                     image_detail = copy.deepcopy(image_detail_record)
 
-                    dockerpresent = imageId = fulltag = "None"
-                    dockerfile = image_detail.pop('dockerfile', None)
-                    if dockerfile:
-                        dockerpresent = "Present"
+                    imageId = fulltag = "None"
 
                     imageId = image_detail.pop('imageId', "None")
                     fulltag = image_detail.pop('registry', "None") + "/" + image_detail.pop('repo', "None") + ":" + image_detail.pop('tag', "None")
@@ -396,15 +393,9 @@ def format_output(config, op, params, payload):
                 outdict['Analyzed At'] = str(image_record['analyzed_at'])
 
                 image_detail = copy.deepcopy(image_record['image_detail'][0])
-                dockerfile = image_detail.pop('dockerfile', None)
-
-                dockerpresent = "None"
-                if dockerfile:
-                    dockerpresent = "Present"
 
                 imageId = image_detail.pop('imageId', "None")
                 outdict['Image ID'] = str(imageId)
-                #outdict['Dockerfile'] = str(dockerpresent)
 
                 if 'image_content' in image_record and image_record['image_content']:
                     image_content = image_record['image_content']
@@ -549,7 +540,6 @@ def format_output(config, op, params, payload):
             t = PrettyTable(header)
             t.set_style(PLAIN_COLUMNS)
             t.align = 'l'
-            last_updated = payload['metadata']['last_updated']
             for record in payload['content']:
                 if record.get('type', None) == 'bundle':
                     row = [textwrap.fill(record['name'], width=40), textwrap.fill(record['description'], width=60)]
@@ -798,8 +788,6 @@ def format_output(config, op, params, payload):
         elif op == 'event_get':
             ret = yaml.safe_dump(payload['event'], default_flow_style=False)
         elif op == 'query_images_by_vulnerability':
-            vulnerability_id = params.get('vulnerability_id')
-            #header = ['Severity', 'Full Tag', 'Package', 'Package Type', 'Namespace', 'Digest']
             header = ['Full Tag', 'Severity', 'Package', 'Package Type', 'Namespace', 'Digest']
             t = PrettyTable(header)
             t.set_style(PLAIN_COLUMNS)
@@ -811,7 +799,6 @@ def format_output(config, op, params, payload):
                         t.add_row(row)
             ret = t.get_string()
         elif op == 'query_images_by_package':
-            vulnerability_id = params.get('vulnerability_id')
             header = ['Full Tag', 'Package', 'Package Type', 'Digest']
             t = PrettyTable(header)
             t.set_style(PLAIN_COLUMNS)
@@ -1129,9 +1116,6 @@ def discover_inputimage_format(config, input_string):
     return(itype)
 
 def discover_inputimage(config, input_string):
-    type = None
-    image = None
-
     patt = re.match("(.*@|^)(sha256:.*)", input_string)
     if patt:
         urldigest = quote_plus(patt.group(2))

--- a/anchorecli/clients/apiexternal.py
+++ b/anchorecli/clients/apiexternal.py
@@ -1,15 +1,14 @@
 import json
 import re
 import requests
-import hashlib
 import logging
 import urllib3
 import requests.packages.urllib3
 try:
     from urllib.parse import urlparse, urlunparse, urlencode, quote
-except:
+except ImportError:
     from urllib import urlencode, quote
-    from urlparse import urlparse,urlunparse
+    from urlparse import urlparse, urlunparse
 
 requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -85,7 +84,7 @@ def system_feeds_sync(config, flush=False):
     except Exception as err:
         raise err
 
-    return(ret)    
+    return(ret)
 
 def system_status(config):
     userId = config['user']
@@ -115,7 +114,7 @@ def delete_system_service(config, host_id, servicename):
     if not host_id or not servicename:
         raise Exception("invalid host_id or servicename given")
 
-    ret = {}    
+    ret = {}
 
     base_url = re.sub("/$", "", base_url)
     url = '/'.join([base_url, "system", "services", servicename, host_id])
@@ -332,7 +331,7 @@ def import_image(config, anchore_data=[]):
     ret = []
 
     payload = anchore_data[0]
-    
+
     base_url = re.sub("/$", "", base_url)
     url = '/'.join([base_url, "imageimport"])
     set_account_header(config)
@@ -356,7 +355,7 @@ def query_image(config, imageDigest=None, query_group=None, query_type=None, ven
 
     base_url = re.sub("/$", "", base_url)
     url = '/'.join([base_url, "images", imageDigest])
-    
+
     if query_group:
         url = '/'.join([url, query_group])
     else:
@@ -458,7 +457,7 @@ def get_policy(config, policyId=None, detail=False):
         _logger.debug("GET url="+str(url))
         r = requests.get(url, auth=(userId, password), verify=config['ssl_verify'], headers=header_overrides)
         ret = anchorecli.clients.common.make_client_result(r, raw=False)
-        
+
     except Exception as err:
         raise err
 
@@ -578,7 +577,7 @@ def activate_subscription(config, subscription_type, subscription_key):
 
     ret = {}
 
-    # first - get the subscription record from engine, to get the right subscription_id for the record 
+    # first - get the subscription record from engine, to get the right subscription_id for the record
     try:
         subscription_response = get_subscription(config, subscription_type, subscription_key)
         subscription_records = subscription_response.get('payload', [])
@@ -594,7 +593,7 @@ def activate_subscription(config, subscription_type, subscription_key):
 
     base_url = re.sub("/$", "", base_url)
     url = '/'.join([base_url, "subscriptions", subscription_id])
-    
+
     payload = {'active':True, 'subscription_key': subscription_key, 'subscription_type': subscription_type}
     set_account_header(config)
 
@@ -614,7 +613,7 @@ def deactivate_subscription(config, subscription_type, subscription_key):
 
     ret = {}
 
-    # first - get the subscription record from engine, to get the right subscription_id for the record 
+    # first - get the subscription record from engine, to get the right subscription_id for the record
     try:
         subscription_response = get_subscription(config, subscription_type, subscription_key)
         subscription_records = subscription_response.get('payload', [])
@@ -672,7 +671,7 @@ def delete_subscription(config, subscription_type=None, subscription_key=None):
 
     ret = {}
 
-    # first - get the subscription record from engine, to get the right subscription_id for the record 
+    # first - get the subscription record from engine, to get the right subscription_id for the record
     try:
         subscription_response = get_subscription(config, subscription_type, subscription_key)
         subscription_records = subscription_response.get('payload', [])
@@ -697,7 +696,7 @@ def delete_subscription(config, subscription_type=None, subscription_key=None):
     except Exception as err:
         raise err
 
-    return(ret)    
+    return(ret)
 
 def get_subscription(config, subscription_type=None, subscription_key=None):
     userId = config['user']
@@ -771,6 +770,7 @@ def add_repo(config, input_repo, autosubscribe=False, lookuptag=None):
 
     return(ret)
     #return(add_subscription(config, 'repo_update', input_repo))
+
 
 def get_repo(config, input_repo=None):
     userId = config['user']
@@ -948,7 +948,7 @@ def describe_error_codes(config):
     except Exception as err:
         raise err
 
-    return(ret)    
+    return(ret)
 
 def describe_policy_spec(config):
     userId = config['user']
@@ -1154,7 +1154,7 @@ def query_images_by_vulnerability(config, vulnerability_id, namespace=None, affe
         query_params['severity'] = severity
     if vendor_only:
         query_params['vendor_only'] = vendor_only
-    
+
     if query_params:
         url = "{}&{}".format(url, urlencode(query_params))
 
@@ -1189,7 +1189,7 @@ def query_images_by_package(config, name, version=None, package_type=None):
         query_params['version'] = version
     if package_type:
         query_params['package_type'] = package_type
-    
+
     if query_params:
         url = "{}&{}".format(url, urlencode(query_params))
 
@@ -1469,7 +1469,7 @@ def update_user_password(config, account_name=None, user_name=None, user_passwor
     except Exception as err:
         raise err
 
-    return(ret)        
+    return(ret)
 
 
 def list_archives(config):

--- a/anchorecli/clients/apiexternal.py
+++ b/anchorecli/clients/apiexternal.py
@@ -773,12 +773,6 @@ def add_repo(config, input_repo, autosubscribe=False, lookuptag=None):
 
 
 def get_repo(config, input_repo=None):
-    userId = config['user']
-    password = config['pass']
-    base_url = config['url']
-
-    ret = {}
-
     set_account_header(config)
 
     filtered_records = []
@@ -792,7 +786,7 @@ def get_repo(config, input_repo=None):
 
     subscriptions['payload'] = filtered_records
 
-    return(subscriptions)
+    return subscriptions
 
 def delete_repo(config, input_repo, force=False):
     return(delete_subscription(config, 'repo_update', input_repo))

--- a/anchorecli/clients/common.py
+++ b/anchorecli/clients/common.py
@@ -1,6 +1,4 @@
 import json
-import re
-import os
 
 
 def make_client_result(response, raw=False):

--- a/anchorecli/clients/common.py
+++ b/anchorecli/clients/common.py
@@ -1,41 +1,39 @@
 import json
 
 
+def _safe_loads(text):
+    try:
+        return json.loads(text)
+    except Exception:
+        return text
+
+
 def make_client_result(response, raw=False):
     ret = {
-        'success':False,
-        'httpcode':0,
-        'payload':{},
-        'error':{}
+        'success': False,
+        'httpcode': 0,
+        'payload': {},
+        'error': {}
     }
 
-    try:
-        ret['httpcode'] = response.status_code
+    ret['httpcode'] = response.status_code
 
-        if response.status_code in range(200, 299):
-            ret['success'] = True
-            if raw == True:
-                ret['payload'] = response.text
-            else:
-                try:
-                    ret['payload'] = json.loads(response.text)
-                except:
-                    ret['payload'] = response.text
-
+    if response.status_code in range(200, 299):
+        ret['success'] = True
+        if raw is True:
+            ret['payload'] = response.text
         else:
-            ret['success'] = False
+            ret['payload'] = _safe_loads(response.text)
 
-            if raw == True:
-                ret['error'] = response.text
-            else:
-                try:
-                    ret['error'] = json.loads(response.text)
-                except:
-                    ret['error'] = response.text
+    else:
+        ret['success'] = False
 
-            if not ret.get('error', None) and response.status_code in [401]:
-                ret['error'] = "Unauthorized - please check your username/password"
-    except Exception as err:
-        raise err
+        if raw is True:
+            ret['error'] = response.text
+        else:
+            ret['error'] = _safe_loads(response.text)
 
-    return(ret)
+        if not ret.get('error', None) and response.status_code in [401]:
+            ret['error'] = "Unauthorized - please check your username/password"
+
+    return ret

--- a/anchorecli/clients/hub.py
+++ b/anchorecli/clients/hub.py
@@ -1,16 +1,8 @@
-import json
 import re
 import requests
-import hashlib
 import logging
 import urllib3
-import uuid
 import requests.packages.urllib3
-try:
-    from urllib.parse import urlparse, urlunparse, urlencode
-except:
-    from urllib import urlencode
-    from urlparse import urlparse,urlunparse
 
 requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -18,6 +10,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 import anchorecli.clients.common
 
 _logger = logging.getLogger(__name__)
+
 
 def _get_hub_index(config, auth=(None, None)):
     base_url = re.sub("/$", "", config['hub-url'])
@@ -33,6 +26,7 @@ def _get_hub_index(config, auth=(None, None)):
     except Exception as err:
         raise err
     return(index)
+
 
 def _fetch_bundle(config, bundlename=None, auth=(None, None)):
     base_url = re.sub("/$", "", config['hub-url'])
@@ -60,6 +54,7 @@ def _fetch_bundle(config, bundlename=None, auth=(None, None)):
 
     return(bundle)
 
+
 def get_policy(config, bundlename, auth=(None, None)):
     ret = {
         'success': False,
@@ -78,6 +73,7 @@ def get_policy(config, bundlename, auth=(None, None)):
 
     return(ret)
 
+
 def get_policies(config, auth=(None, None)):
     ret = {
         'success': False,
@@ -95,6 +91,7 @@ def get_policies(config, auth=(None, None)):
         ret['error'] = str(err)
 
     return(ret)
+
 
 def install_policy(config, bundlename, target_id=None, force=False, auth=(None, None)):
     ret = {

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
-#!/usr/bin/python
 from setuptools import setup, find_packages
-import os, shutil, errno
 from anchorecli import version
 
-version =  version.version
+version = version.version
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
@@ -15,7 +13,6 @@ long_description = open('README.rst').read()
 
 url = 'http://www.anchore.com'
 
-#package_data = {}
 package_data = {
     package_name: [
         'cli/*',
@@ -24,14 +21,7 @@ package_data = {
     ]
 }
 
-#data_files = [('conf', ['conf/config.yaml.example'])]
 data_files = []
-#data_files = [('datafiles', ['datafiles/lynis-data.tar'])]
-#data_files = [
-#    ('twisted', ['anchore_service/twisted/*'])
-#]
-#packages=find_packages(exclude=('run*', 'log*', 'conf*', 'dead*', 'scripts/*')),
-#scripts = ['scripts/anchore-service.sh', 'scripts/anchore-service']
 scripts = []
 
 setup(
@@ -54,7 +44,3 @@ setup(
     install_requires=requirements,
     scripts=scripts
 )
-#    entry_points='''
-#    [console_scripts]
-#    anchore=anchore.cli:main_entry
-#    ''',

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,18 @@ setup(
     anchore-cli=anchorecli.cli:main_entry
     ''',
     install_requires=requirements,
-    scripts=scripts
+    scripts=scripts,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'Intended Audience :: Information Technology',
+        'Topic :: Security',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ]
 )

--- a/tests/cli/test_account.py
+++ b/tests/cli/test_account.py
@@ -1,0 +1,1 @@
+from anchorecli.cli import account

--- a/tests/cli/test_archives.py
+++ b/tests/cli/test_archives.py
@@ -1,0 +1,1 @@
+from anchorecli.cli import archives

--- a/tests/cli/test_evaluate.py
+++ b/tests/cli/test_evaluate.py
@@ -1,0 +1,2 @@
+from anchorecli.cli import evaluate
+

--- a/tests/cli/test_event.py
+++ b/tests/cli/test_event.py
@@ -1,0 +1,1 @@
+from anchorecli.cli import event

--- a/tests/cli/test_image.py
+++ b/tests/cli/test_image.py
@@ -1,0 +1,1 @@
+from anchorecli.cli import image

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -1,0 +1,1 @@
+from anchorecli.cli import policy

--- a/tests/cli/test_query.py
+++ b/tests/cli/test_query.py
@@ -1,0 +1,1 @@
+from anchorecli.cli import query

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -1,0 +1,1 @@
+from anchorecli.cli import registry

--- a/tests/cli/test_repo.py
+++ b/tests/cli/test_repo.py
@@ -1,0 +1,1 @@
+from anchorecli.cli import repo

--- a/tests/cli/test_subscription.py
+++ b/tests/cli/test_subscription.py
@@ -1,0 +1,1 @@
+from anchorecli.cli import subscription

--- a/tests/cli/test_system.py
+++ b/tests/cli/test_system.py
@@ -1,0 +1,1 @@
+from anchorecli.cli import system

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,0 +1,2 @@
+from anchorecli.cli import utils
+

--- a/tests/clients/test_apiexternal.py
+++ b/tests/clients/test_apiexternal.py
@@ -1,0 +1,1 @@
+from anchorecli.clients import apiexternal

--- a/tests/clients/test_hub.py
+++ b/tests/clients/test_hub.py
@@ -1,0 +1,1 @@
+from anchorecli.clients import hub

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = py27, py35, py36, py37, flake8
+skip_missing_interpreters = true
+
+[testenv]
+deps=
+  pytest
+
+commands=pytest -v {posargs:tests}
+
+[testenv:flake8]
+deps=flake8
+commands=flake8 {posargs:anchorecli}
+
+[tool:pytest]
+norecursedirs = .* _* virtualenv
+
+[flake8]
+select=F,E9
+


### PR DESCRIPTION
This PR introduces the test harness via tox, hooking it up to the CI. I *think* that it will allow reporting on PRs which is the intention. Since this project supports Python 2.7 and Python 3 it adds capabilities for both.

There are a lot of import removals and unused variables, as reported from flake8:

```
$ flake8 --select=F,E9 anchorecli
anchorecli/clients/hub.py:1:1: F401 'json' imported but unused
anchorecli/clients/hub.py:4:1: F401 'hashlib' imported but unused
anchorecli/clients/hub.py:7:1: F401 'uuid' imported but unused
anchorecli/clients/hub.py:12:5: F401 'urllib.urlencode' imported but unused
anchorecli/clients/hub.py:13:5: F401 'urlparse.urlparse' imported but unused
anchorecli/clients/hub.py:13:5: F401 'urlparse.urlunparse' imported but unused
anchorecli/clients/common.py:2:1: F401 're' imported but unused
anchorecli/clients/common.py:3:1: F401 'os' imported but unused
anchorecli/clients/apiexternal.py:4:1: F401 'hashlib' imported but unused
anchorecli/clients/apiexternal.py:776:5: F841 local variable 'userId' is assigned to but never used
anchorecli/clients/apiexternal.py:777:5: F841 local variable 'password' is assigned to but never used
anchorecli/clients/apiexternal.py:778:5: F841 local variable 'base_url' is assigned to but never used
anchorecli/clients/apiexternal.py:780:5: F841 local variable 'ret' is assigned to but never used
anchorecli/cli/system.py:2:1: F401 'os' imported but unused
anchorecli/cli/system.py:3:1: F401 're' imported but unused
anchorecli/cli/system.py:92:13: F841 local variable 'err' is assigned to but never used
anchorecli/cli/system.py:240:9: F841 local variable 'err' is assigned to but never used
anchorecli/cli/query.py:2:1: F401 'os' imported but unused
anchorecli/cli/query.py:3:1: F401 're' imported but unused
anchorecli/cli/subscription.py:2:1: F401 'os' imported but unused
anchorecli/cli/subscription.py:3:1: F401 're' imported but unused
anchorecli/cli/registry.py:2:1: F401 'os' imported but unused
anchorecli/cli/__init__.py:1:1: F401 'os' imported but unused
anchorecli/cli/__init__.py:3:1: F401 'subprocess' imported but unused
anchorecli/cli/__init__.py:4:1: F401 'sys' imported but unused
anchorecli/cli/__init__.py:10:1: F401 'anchorecli.clients' imported but unused
anchorecli/cli/utils.py:9:1: F401 'struct' imported but unused
anchorecli/cli/utils.py:190:5: F841 local variable 'err' is assigned to but never used
anchorecli/cli/utils.py:250:57: F841 local variable 'registy' is assigned to but never used
anchorecli/cli/utils.py:362:21: F841 local variable 'err' is assigned to but never used
anchorecli/cli/utils.py:401:21: F841 local variable 'dockerpresent' is assigned to but never used
anchorecli/cli/utils.py:550:13: F841 local variable 'last_updated' is assigned to but never used
anchorecli/cli/utils.py:810:13: F841 local variable 'vulnerability_id' is assigned to but never used
anchorecli/cli/utils.py:1077:5: F841 local variable 'err' is assigned to but never used
anchorecli/cli/utils.py:1124:5: F841 local variable 'type' is assigned to but never used
anchorecli/cli/utils.py:1125:5: F841 local variable 'image' is assigned to but never used
anchorecli/cli/utils.py:1140:5: F841 local variable 'err' is assigned to but never used
anchorecli/cli/utils.py:1155:13: F841 local variable 'err' is assigned to but never used
anchorecli/cli/utils.py:1159:5: F841 local variable 'err' is assigned to but never used
anchorecli/cli/repo.py:2:1: F401 'os' imported but unused
anchorecli/cli/repo.py:3:1: F401 're' imported but unused
anchorecli/cli/image.py:2:1: F401 'os' imported but unused
anchorecli/cli/image.py:3:1: F401 're' imported but unused
anchorecli/cli/image.py:125:21: F841 local variable 'err' is assigned to but never used
anchorecli/cli/account.py:2:1: F401 'os' imported but unused
anchorecli/cli/account.py:220:1: F811 redefinition of unused 'whoami' from line 45
```

Finally, it adds a small refactoring on `anchorecli.clients.common` that is backed up by unit tests introduced in a previous PR. Since the changes were getting too large, I decided not to remove/fix other pending things like:

* Avoid using `return(value)` 
* Remove `try/except` blocks that just re-raise the exception without handling
