### PR TITLE
Produce hints when JSON fails validation

### DIFF
--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -158,38 +158,29 @@ def group_list_of_dicts(indict, bykey):
             ret.append(el)
     return(ret)
 
-def format_error_output(config, op, params, payload):
 
+def format_error_output(config, op, params, payload):
     try:
         errdata = json.loads(str(payload))
-    except:
+    except ValueError:
         errdata = {'message': str(payload)}
 
     if config['jsonmode']:
-        ret = json.dumps(errdata, indent=4, sort_keys=True)
-        return(ret)
-
-    # error message overrides
-    #if op == 'image_add':
-        #if 'httpcode' in errdata and errdata['httpcode'] == 404:
-        #    errdata['message'] = "image cannot be found/fetched from registry"
+        return json.dumps(errdata, indent=4, sort_keys=True)
 
     obuf = ""
-    try:
-        outdict = OrderedDict()
-        if 'message' in errdata:
-            outdict['Error'] = str(errdata['message'])
-        if 'httpcode' in errdata:
-            outdict['HTTP Code'] = str(errdata['httpcode'])
-        if 'detail' in errdata and errdata['detail']:
-            outdict['Detail'] = str(errdata['detail'])
+    outdict = OrderedDict()
+    if 'message' in errdata:
+        outdict['Error'] = str(errdata['message'])
+    if 'httpcode' in errdata:
+        outdict['HTTP Code'] = str(errdata['httpcode'])
+    if 'detail' in errdata and errdata['detail']:
+        outdict['Detail'] = str(errdata['detail'])
 
-        for k in list(outdict.keys()):
-            obuf = obuf + k + ": " + outdict[k] + "\n"
-        if not obuf:
-            raise Exception("not JSON output could be parsed from error response")
-        #obuf = obuf + "\n"
-    except Exception:
+    for k in list(outdict.keys()):
+        obuf = obuf + k + ": " + outdict[k] + "\n"
+
+    if not obuf:
         obuf = str(payload)
 
     # operation-specific output postfixes
@@ -197,8 +188,7 @@ def format_error_output(config, op, params, payload):
         if "Invalid account state change requested" in errdata.get('message', ""):
             obuf = obuf + "\nNOTE: accounts must be disabled (anchore-cli account disable <account>) in order to be deleted\n"
 
-    ret = obuf
-    return(ret)
+    return obuf
 
 
 def format_output(config, op, params, payload):

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 from anchorecli.cli import utils
 
 
@@ -55,3 +56,24 @@ class TestFormatErrorOutputAccountDelete:
     def test_state_change_is_valid(self):
         result = utils.format_error_output(self.config, "account_delete", {}, '{"message": "Unable to delete account"}')
         assert 'Error: Unable to delete account\n' == result
+
+
+class TestCreateHint:
+
+    def test_cannot_create_hint(self):
+        result = utils.create_hint("should not create a hint here")
+        assert result is None
+
+    def test_creates_hint(self):
+        result = utils.create_hint("'id' is a required property")
+        assert 'Hint: The "id" key is not present in the JSON file' in result
+        assert '"id": <value>' in result
+
+    def test_cannot_create_hint(self):
+        result = utils.create_hint("unquoted_value is a required property")
+        assert result is None
+
+    @pytest.mark.parametrize('invalid_type', [None, [], {}, (), 1, True, False])
+    def test_handles_non_strings(self, invalid_type):
+        result = utils.create_hint(invalid_type)
+        assert result is None

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,2 +1,57 @@
 from anchorecli.cli import utils
 
+
+class TestFormatErrorOutput:
+
+    def setup(self):
+        self.config = {'jsonmode': False}
+
+    def test_fails_on_invalid_json(self):
+        payload = Exception('could not access anchore service (user=None url=http://localhost:8228/v1)')
+        result = utils.format_error_output(self.config, "policy", {}, payload)
+        assert result == "Error: could not access anchore service (user=None url=http://localhost:8228/v1)\n"
+
+    def test_empty_json_fallsback(self):
+        result = utils.format_error_output(self.config, "policy", {}, "{}")
+        assert result == '{}'
+
+    def test_httpcode_is_included(self):
+        result = utils.format_error_output(self.config, "policy", {}, '{"httpcode": 200}')
+        assert result == 'HTTP Code: 200\n'
+
+    def test_message_is_included(self):
+        result = utils.format_error_output(self.config, "policy", {}, '{"message": "invalid input!"}')
+        assert result == 'Error: invalid input!\n'
+
+    def test_detail_is_included(self):
+        result = utils.format_error_output(self.config, "policy", {}, '{"detail": "\'id\' is missing"}')
+        assert result == "Detail: 'id' is missing\n"
+
+
+class TestFormatErrorOutputJSONMode:
+
+    def setup(self):
+        self.config = {'jsonmode': True}
+
+    def test_loads_valid_json(self):
+        result = utils.format_error_output(self.config, "policy", {}, '{"message": "valid JSON"}')
+        assert result == '{\n    "message": "valid JSON"\n}'
+
+    def test_builds_valid_json_on_failure(self):
+        result = utils.format_error_output(self.config, "policy", {}, 'invalid JSON!')
+        assert result == '{\n    "message": "invalid JSON!"\n}'
+
+
+class TestFormatErrorOutputAccountDelete:
+
+    def setup(self):
+        self.config = {'jsonmode': False}
+
+    def test_invalid_account(self):
+        result = utils.format_error_output(self.config, "account_delete", {}, '{"message": "Invalid account state change requested"}')
+        assert 'Error: Invalid account state change requested' in result
+        assert 'NOTE: accounts must be disabled (anchore-cli account disable <account>)' in result
+
+    def test_state_change_is_valid(self):
+        result = utils.format_error_output(self.config, "account_delete", {}, '{"message": "Unable to delete account"}')
+        assert 'Error: Unable to delete account\n' == result


### PR DESCRIPTION
Fixes: #31

Example output with no keys in JSON file:

```
$ anchore-cli policy add foo.json
Detail: 'id' is a required property
Hint: The "id" key is not present in the JSON file, make sure it exists:

    {
        "id": <value>
        ...
    }
```



And with `"id"` and nothing else:

```
$ anchore-cli policy add foo.json
Detail: 'version' is a required property
Hint: The "version" key is not present in the JSON file, make sure it exists:

    {
        "version": <value>
        ...
    }
```

I would prefer to have the keys and errors coming in from the validation endpoint rather than to have to extract the information like this. When/if that happens we can clean this up and remove the utility (or expand it to use the richer validation information)