### PR TITLE
exit code granularity on image vulnerability

### DIFF
--- a/anchorecli/cli/image.py
+++ b/anchorecli/cli/image.py
@@ -309,6 +309,7 @@ def query_metadata(input_image, metadata_type):
 
     anchorecli.cli.utils.doexit(ecode)
 
+
 @image.command(name='vuln', short_help="Get image vulnerabilities")
 @click.argument('input_image', nargs=1)
 @click.argument('vuln_type', nargs=1, required=False)
@@ -331,12 +332,15 @@ def query_vuln(input_image, vuln_type, vendor_only):
         else:
             ret = anchorecli.clients.apiexternal.query_image(config, imageDigest=imageDigest, query_group='vuln', query_type=vuln_type, vendor_only=vendor_only)
             ecode = anchorecli.cli.utils.get_ecode(ret)
-
             if ret:
                 if ret['success']:
-                    print(anchorecli.cli.utils.format_output(config, 'image_vuln', {'query_type':vuln_type}, ret['payload']))
+                    print(anchorecli.cli.utils.format_output(config, 'image_vuln', {'query_type': vuln_type}, ret['payload']))
                 else:
-                    raise Exception (json.dumps(ret['error'], indent=4))
+                    if 'analysis_status: analyzing' in ret['error']['message']:
+                        ecode = 100
+                    elif 'analysis_status: not_analyzed' in ret['error']['message']:
+                        ecode = 101
+                    raise Exception(json.dumps(ret['error'], indent=4))
             else:
                 raise Exception("operation failed with empty response")
 
@@ -344,8 +348,8 @@ def query_vuln(input_image, vuln_type, vendor_only):
         print(anchorecli.cli.utils.format_error_output(config, 'image_vuln', {}, err))
         if not ecode:
             ecode = 2
-
     anchorecli.cli.utils.doexit(ecode)
+
 
 @image.command(name='del', short_help="Delete an image")
 @click.argument('input_image', required=False)

--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -123,14 +123,15 @@ def setup_config(cli_opts):
 
 
 def doexit(ecode):
-    try:
-        sys.stdout.close()
-    except Exception:
-        pass
-    try:
-        sys.stderr.close()
-    except Exception:
-        pass
+    if not os.environ.get('ANCHORE_CLI_NO_FDS_CLEANUP'):
+        try:
+            sys.stdout.close()
+        except Exception:
+            pass
+        try:
+            sys.stderr.close()
+        except Exception:
+            pass
     sys.exit(ecode)
 
 

--- a/tests/cli/test_image.py
+++ b/tests/cli/test_image.py
@@ -1,1 +1,120 @@
+import pytest
 from anchorecli.cli import image
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def response(monkeypatch):
+    error = {
+        'success': False,
+        'payload': {},
+        'error': {
+            'detail': {'error_codes': []},
+            'httpcode': 404,
+            'message': 'image is not analyzed - analysis_status: analyzing'
+        },
+        'httpcode': 404,
+    }
+    ok = {
+        'success': True, 'httpcode': 200,
+        'payload': {
+            'imageDigest': 'sha256:0c03ccebef8d908f181a9fbd11eaf84c858be8396c71c89bf1b372ee59852eca',
+            'vulnerabilities': [{
+                'advisory_data': {'cves': ['CVE-2018-19801']},
+                'feed': 'vulnerabilities',
+                'feed_group': 'github:python',
+                'fix': '0.4.9',
+                'nvd_data': [],
+                'package': 'aubio-0.4.8',
+                'package_cpe': 'None',
+                'package_cpe23': 'None',
+                'package_name': 'aubio',
+                'package_path': '/usr/local/lib64/python3.6/site-packages/aubio',
+                'package_type': 'python',
+                'package_version': '0.4.8',
+                'severity': 'High',
+                'url': 'https://github.com/advisories/GHSA-7vvr-h4p5-m7fh',
+                'vendor_data': [],
+                'vuln': 'GHSA-7vvr-h4p5-m7fh'}
+            ],
+            'vulnerability_type': 'all'},
+        'error': {}
+    }
+
+    def apply(success=True, httpcode=200, has_error=None):
+        if success:
+            patch = lambda *a, **kw: ok
+        else:
+            if has_error:
+                error['error'] = has_error
+            patch = lambda *a, **kw: error
+
+        monkeypatch.setattr(image.anchorecli.clients.apiexternal, 'query_image', patch)
+    return apply
+
+
+headers = [
+    'Vulnerability ID',
+    'Package',
+    'Severity',
+    'Fix',
+    'CVE Refs',
+    'Vulnerability URL',
+    'Type',
+    'Feed Group',
+    'Package Path',
+]
+
+vulnerability = [
+    'GHSA-7vvr-h4p5-m7fh',
+    'aubio-0.4.8',
+    'High',
+    '0.4.9',
+    'https://github.com/advisories/GHSA-7vvr-h4p5-m7fh',
+    'python',
+    'github:python',
+    '/usr/local/lib64/python3.6/site-packages/aubio',
+]
+
+
+class TestQueryVuln:
+
+    def test_is_analyzing(self, monkeypatch, response):
+        monkeypatch.setattr(image.anchorecli.cli.utils, 'discover_inputimage', lambda *a, **kw: (None, None, '<digest>'))
+        monkeypatch.setattr(image, 'config', {'jsonmode': False})
+        runner = CliRunner()
+        response(success=False)
+        result = runner.invoke(image.query_vuln, ['centos/centos:8', 'all'])
+        assert result.exit_code == 100
+
+    def test_not_yet_analyzed(self, monkeypatch, response):
+        monkeypatch.setattr(image.anchorecli.cli.utils, 'discover_inputimage', lambda *a, **kw: (None, None, '<digest>'))
+        monkeypatch.setattr(image, 'config', {'jsonmode': False})
+        runner = CliRunner()
+        response(success=False, has_error={
+            'detail': {'error_codes': []},
+            'httpcode': 404,
+            'message': 'image is not analyzed - analysis_status: not_analyzed'
+        })
+        result = runner.invoke(image.query_vuln, ['centos/centos:8', 'all'])
+        assert result.exit_code == 101
+
+    @pytest.mark.parametrize('item', headers)
+    def test_success_headers(self, monkeypatch, response, item):
+        monkeypatch.setattr(image.anchorecli.cli.utils, 'discover_inputimage', lambda *a, **kw: (None, None, '<digest>'))
+        monkeypatch.setattr(image, 'config', {'jsonmode': False})
+        runner = CliRunner()
+        response(success=True)
+        result = runner.invoke(image.query_vuln, ['centos/centos:8', 'all'])
+        assert result.exit_code == 0
+        assert item in result.stdout
+
+    @pytest.mark.parametrize('item', vulnerability)
+    def test_success_info(self, monkeypatch, response, item):
+        monkeypatch.setattr(image.anchorecli.cli.utils, 'discover_inputimage', lambda *a, **kw: (None, None, '<digest>'))
+        monkeypatch.setattr(image, 'config', {'jsonmode': False})
+        runner = CliRunner()
+        response(success=True)
+        result = runner.invoke(image.query_vuln, ['centos/centos:8', 'all'])
+        assert result.exit_code == 0
+        assert item in result.stdout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,18 @@ def stub_response():
         response = Factory(status_code=status_code, text=text)
         return response
     return apply
+
+
+@pytest.fixture(autouse=True)
+def no_fds_closing(monkeypatch):
+    """
+    The ClickRunner test helper breaks when stdout and stderr is closed as it is trying to capture
+    whatever the tool was sending as output. This env is prevents anchore-cli from closing them
+    allowing the ClickRunner to work.
+
+    Related issues:
+
+    * https://github.com/pallets/click/issues/824
+    * https://github.com/pytest-dev/pytest/issues/3344
+    """
+    monkeypatch.setenv('ANCHORE_CLI_NO_FDS_CLEANUP', '1')


### PR DESCRIPTION
Fixes issue https://github.com/anchore/anchore-cli/issues/6

Sets exit `100` when analyzing, and `101` for `not_analyzed`