### PR TITLE
Utilize licenses content response field

### DIFF
--- a/anchorecli/__main__.py
+++ b/anchorecli/__main__.py
@@ -1,0 +1,3 @@
+from anchorecli.cli import main_entry
+
+main_entry()

--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -299,10 +299,11 @@ def format_output(config, op, params, payload):
                 obuf = obuf + "\n"
             else:
                 if params['query_type'] == 'os':
-                    header = ['Package', 'Version', 'License']
+                    header = ['Package', 'Version', 'Licenses']
                     t = plain_column_table(header)
                     for el in payload['content']:
-                        row = [el['package'], el['version'], el['license']]
+                        licenses = el.get('licenses', [el.get('license')])
+                        row = [el['package'], el['version'], " ".join(licenses)]
                         t.add_row(row)
                     obuf = obuf + t.get_string(sortby='Package')
                 elif params['query_type'] == 'files':


### PR DESCRIPTION
Related to https://github.com/anchore/anchore-engine/pull/439 , utilizes the new `licenses` field over the soon-to-be-deprecated `license` field. In case the `licenses` field is no present, behavior is to fall back to using the original `license` field.

Minor addition: added a `__main__.py` to aid in a targeted entrypoint for use by a debugger (`python -m anchorecli image get`) instead of depending on an on-path shim.