### PR TITLE
Fix empty content response for manifest/dockerfile/docker_history

### DIFF
--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -328,7 +328,7 @@ def format_output(config, op, params, payload):
                     obuf = obuf + t.get_string(sortby='Package')
                 elif params['query_type'] in ['manifest', 'dockerfile', 'docker_history']:
                     try:
-                        obuf = base64.b64decode(payload.get('metadata', "")).decode('utf-8')
+                        obuf = base64.b64decode(payload.get('content', "")).decode('utf-8')
                     except Exception:
                         obuf = ""
                 else:


### PR DESCRIPTION
Currently `anchore-cli image content <img> manifest|dockerfile|docker_history` results in no output, this PR addresses this behavior.