### PR TITLE
Functional tests for an image

### DIFF
--- a/anchorecli/cli/image.py
+++ b/anchorecli/cli/image.py
@@ -255,7 +255,10 @@ def query_content(input_image, content_type):
             ecode = anchorecli.cli.utils.get_ecode(ret)
             if ret:
                 if ret['success']:
-                    print(anchorecli.cli.utils.format_output(config, 'image_content', {'query_type':content_type}, ret['payload']))
+                    output = anchorecli.cli.utils.format_output(config, 'image_content', {'query_type':content_type}, ret['payload'])
+                    if not output:
+                        raise Exception('There is no image content (%s) to provide for %s' % (content_type, input_image))
+                    print(output)
                 else:
                     raise Exception (json.dumps(ret['error'], indent=4))
             else:

--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -327,10 +327,7 @@ def format_output(config, op, params, payload):
                         t.add_row(row)
                     obuf = obuf + t.get_string(sortby='Package')
                 elif params['query_type'] in ['manifest', 'dockerfile', 'docker_history']:
-                    try:
-                        obuf = base64.b64decode(payload.get('content', "")).decode('utf-8')
-                    except Exception:
-                        obuf = ""
+                    obuf = format_content_query(payload)
                 else:
                     try:
                         if payload['content']:
@@ -932,6 +929,22 @@ def format_vulnerabilities(payload, params):
         obuf = obuf + t.get_string(sortby='Severity')
 
     return obuf
+
+
+def format_content_query(payload):
+    content = payload.get('content', '')
+    if not content:
+        return ''
+    if isinstance(content, list):
+        # In some situations the `content` key can be a list, not a string
+        content = ''.join(content)
+    try:
+        return base64.b64decode(content).decode('utf-8')
+    except Exception:
+        # This broad exception catching is warranted here because there are all
+        # sort of warts we would need to catch with utf-8 decoding and
+        # b64decode. The actual exception is not that relevant here
+        return ''
 
 
 def string_splitter(input_str, max_length=40):

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -126,3 +126,28 @@ class TestFormatVulnerabilities:
             'centos:7',
             'None',
         ]
+
+
+class TestFormatContentQuery:
+
+    def test_no_content(self):
+        payload = {}
+        result = utils.format_content_query(payload)
+        assert result == ''
+
+    @pytest.mark.parametrize('content', [[], '', None])
+    def test_content_defined_but_empty(self, content):
+        payload = {'content': content}
+        result = utils.format_content_query(payload)
+        assert result == ''
+
+    def test_content_cannot_be_decoded(self):
+        payload = {'content': b'\t23hsdf'}
+        result = utils.format_content_query(payload)
+        assert result == ''
+
+    @pytest.mark.parametrize('content', [b'RlJPTSBjZW50b3M3', 'RlJPTSBjZW50b3M3'])
+    def test_content_gets_decoded(self, content):
+        payload = {'content': content}
+        result = utils.format_content_query(payload)
+        assert result == 'FROM centos7'

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -131,7 +131,10 @@ def pytest_runtest_logreport(report):
             log_lines = [
                 ("Container ID: {!r}:".format(container.attrs['Id'])),
                 ] + container.logs().decode('utf-8').split('\n')[-10:]
-            report.longrepr.addsection('docker logs', os.linesep.join(log_lines))
+            try:
+                report.longrepr.addsection('docker logs', os.linesep.join(log_lines))
+            except AttributeError:
+                pass
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -326,16 +329,36 @@ def call(command, **kw):
     return stdout_stream, stderr_stream, returncode
 
 
+def _call(command, **kw):
+    if command[0] != 'anchore-cli':
+        command.insert(0, 'anchore-cli')
+    return call(
+        command,
+        env={'ANCHORE_CLI_USER': 'admin', 'ANCHORE_CLI_PASS': 'foobar'},
+        **kw
+    )
+
+
+@pytest.fixture(scope='session')
+def session_admin_call():
+    """
+    Same as a plain admin call, but scoped for the session (runs once per test
+    session)
+    """
+    return _call
+
+
+@pytest.fixture(scope='class')
+def class_admin_call():
+    """
+    Same as a plain admin call, but scoped for a class (runs once for a whole
+    class)
+    """
+    return _call
+
+
 @pytest.fixture
 def admin_call():
-    def _call(command, **kw):
-        if command[0] != 'anchore-cli':
-            command.insert(0, 'anchore-cli')
-        return call(
-            command,
-            env={'ANCHORE_CLI_USER': 'admin', 'ANCHORE_CLI_PASS': 'foobar'},
-            **kw
-        )
     return _call
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -34,6 +34,10 @@ def pytest_sessionstart(session):
 
     root_logger.addHandler(fh)
 
+    # Setup the environment variable for the container
+    image = os.environ.get('PYTEST_CONTAINER', 'anchore/inline-scan:latest')
+    os.environ['PYTEST_CONTAINER'] = image
+
 
 def use_environ():
     """
@@ -142,6 +146,7 @@ def inline_scan(client, request):
     # If the container is already running, this will return the running
     # container identified with `pytest_inline_scan`
     image = os.environ.get('PYTEST_CONTAINER', 'anchore/inline-scan:latest')
+    os.environ['PYTEST_CONTAINER'] = image
     container = start_container(
         client,
         image=image,

--- a/tests/functional/image/conftest.py
+++ b/tests/functional/image/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def add_image(session_admin_call):
+    """
+    This fixture will add the vulnerable image so that it can be analyzed, and only when
+    tests executed in the `image` directory are called.
+
+    TODO: Pin this to a specific digest
+    """
+    session_admin_call(['anchore-cli', 'image', 'add', 'alfredodeza/vulnerable'])
+    session_admin_call(['anchore-cli', 'image', 'wait', 'alfredodeza/vulnerable'])

--- a/tests/functional/image/test_content.py
+++ b/tests/functional/image/test_content.py
@@ -1,0 +1,51 @@
+import json
+import pytest
+
+class TestDockerfile:
+
+    @pytest.fixture(scope='class')
+    def stdout(self, class_admin_call):
+        out, err, code = class_admin_call(
+            ['image', 'content', 'alfredodeza/vulnerable', 'dockerfile']
+        )
+        return out
+
+    @pytest.mark.skip(reason="TODO: Fails on empty list")
+    def test_dockerfile(self, stdout):
+        # XXX this fails when uncommenting the exception eater in cli/utils.py
+        # XXX investigate why dockerfile is an empty list
+        # WARNING: failed to format output (returning raw output) - exception: argument should be a bytes-like object or ASCII string, not 'list'
+        # {
+        #     "content": [],
+        #     "content_type": "dockerfile",
+        #     "imageDigest": "sha256:0c03ccebef8d908f181a9fbd11eaf84c858be8396c71c89bf1b372ee59852eca"
+        # }
+        assert ''.join(stdout) == ''
+
+class TestManifest:
+
+    @pytest.fixture(scope='class')
+    def stdout(self, class_admin_call):
+        out, err, code = class_admin_call(
+            ['image', 'content', 'alfredodeza/vulnerable', 'manifest']
+        )
+        try:
+            return json.loads(out)
+        except ValueError:
+            raise ValueError('Unable to parse invalid JSON: %s' % str(out))
+
+    def test_config(self, stdout):
+        assert stdout['config']['digest']  == 'sha256:ab34be85ba4deaf0ba4770c6e4e61eaf56e4415a219867988dba2a0763f82503'
+        assert stdout['config']['mediaType']  == 'application/vnd.docker.container.image.v1+json'
+        assert stdout['config']['size']  == 2755
+
+    def test_layers(self, stdout):
+        # this is somewhat lazy, could look into each layer and digest
+        # mediaType, and size
+        assert len(stdout['layers']) == 2
+
+    def test_mediaType(self, stdout):
+        assert stdout['mediaType'] == 'application/vnd.docker.distribution.manifest.v2+json'
+
+    def test_schemaVersion(self, stdout):
+        assert stdout['schemaVersion'] == 2

--- a/tests/functional/image/test_content.py
+++ b/tests/functional/image/test_content.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 
+
 class TestDockerfile:
 
     @pytest.fixture(scope='class')
@@ -8,19 +9,12 @@ class TestDockerfile:
         out, err, code = class_admin_call(
             ['image', 'content', 'alfredodeza/vulnerable', 'dockerfile']
         )
-        return out
+        return ''.join(out)
 
-    @pytest.mark.skip(reason="TODO: Fails on empty list")
-    def test_dockerfile(self, stdout):
-        # XXX this fails when uncommenting the exception eater in cli/utils.py
-        # XXX investigate why dockerfile is an empty list
-        # WARNING: failed to format output (returning raw output) - exception: argument should be a bytes-like object or ASCII string, not 'list'
-        # {
-        #     "content": [],
-        #     "content_type": "dockerfile",
-        #     "imageDigest": "sha256:0c03ccebef8d908f181a9fbd11eaf84c858be8396c71c89bf1b372ee59852eca"
-        # }
-        assert ''.join(stdout) == ''
+    def test_no_dockerfile(self, stdout):
+        msg = 'Error: There is no image content (dockerfile) to provide for alfredodeza/vulnerable\n\n'
+        assert stdout == msg
+
 
 class TestManifest:
 
@@ -29,15 +23,17 @@ class TestManifest:
         out, err, code = class_admin_call(
             ['image', 'content', 'alfredodeza/vulnerable', 'manifest']
         )
+        if not out:
+            return {}
         try:
             return json.loads(out)
         except ValueError:
             raise ValueError('Unable to parse invalid JSON: %s' % str(out))
 
     def test_config(self, stdout):
-        assert stdout['config']['digest']  == 'sha256:ab34be85ba4deaf0ba4770c6e4e61eaf56e4415a219867988dba2a0763f82503'
-        assert stdout['config']['mediaType']  == 'application/vnd.docker.container.image.v1+json'
-        assert stdout['config']['size']  == 2755
+        assert stdout['config']['digest'] == 'sha256:ab34be85ba4deaf0ba4770c6e4e61eaf56e4415a219867988dba2a0763f82503'
+        assert stdout['config']['mediaType'] == 'application/vnd.docker.container.image.v1+json'
+        assert stdout['config']['size'] == 2755
 
     def test_layers(self, stdout):
         # this is somewhat lazy, could look into each layer and digest
@@ -49,3 +45,68 @@ class TestManifest:
 
     def test_schemaVersion(self, stdout):
         assert stdout['schemaVersion'] == 2
+
+
+class TestDockerHistory:
+
+    @pytest.fixture(scope='class')
+    def stdout(self, class_admin_call):
+        out, err, code = class_admin_call(
+            ['image', 'content', 'alfredodeza/vulnerable', 'docker_history']
+        )
+        if not out:
+            return {}
+        try:
+            return json.loads(out)
+        except ValueError:
+            raise ValueError('Unable to parse invalid JSON: %s' % str(out))
+
+    def test_history_length(self, stdout):
+        assert len(stdout) == 4
+
+    def test_comments(self, stdout):
+        # This is prety ugly, but can't parametrize fixtures :(
+        assert stdout[0]['Comment'] == ''
+        assert stdout[1]['Comment'] == ''
+        assert stdout[2]['Comment'] == ''
+        assert stdout[3]['Comment'] == ''
+
+    def test_created_by_0(self, stdout):
+        created_by = stdout[0]['CreatedBy']
+        assert created_by == (
+            '/bin/sh -c #(nop) ADD '
+           'file:aa54047c80ba30064fe59adf4c978a929f38480be77af9ac644074bd5288ef18 '
+           'in / '
+        )
+
+    def test_created_by_1(self, stdout):
+        created_by = stdout[1]['CreatedBy']
+        assert created_by == (
+            '/bin/sh -c #(nop)  LABEL org.label-schema.schema-version=1.0 '
+            'org.label-schema.name=CentOS Base Image '
+            'org.label-schema.vendor=CentOS org.label-schema.license=GPLv2 '
+            'org.label-schema.build-date=20200114 '
+            'org.opencontainers.image.title=CentOS Base Image '
+            'org.opencontainers.image.vendor=CentOS '
+            'org.opencontainers.image.licenses=GPL-2.0-only '
+            'org.opencontainers.image.created=2020-01-14 00:00:00-08:00'
+        )
+
+    def test_created_by_2(self, stdout):
+        created_by = stdout[2]['CreatedBy']
+        assert created_by == '/bin/sh -c #(nop)  CMD ["/bin/bash"]'
+
+    def test_created_by_3(self, stdout):
+        created_by = stdout[3]['CreatedBy']
+        assert created_by == '/bin/bash'
+
+    # TODO: add all the other keys, sample output:
+    # {'Comment': '',
+    #  'Created': '2020-01-15T01:19:50.271835016Z',
+    #  'CreatedBy': '/bin/sh -c #(nop) ADD '
+    #               'file:aa54047c80ba30064fe59adf4c978a929f38480be77af9ac644074bd5288ef18 '
+    #               'in / ',
+    #  'Id': 'sha256:8a29a15cefaeccf6545f7ecf11298f9672d2f0cdaf9e357a95133ac3ad3e1f07',
+    #  'Size': 73228446,
+    #  'Tags': []},
+

--- a/tests/functional/image/test_vuln.py
+++ b/tests/functional/image/test_vuln.py
@@ -1,0 +1,86 @@
+import os
+import pytest
+
+skip_versions = [
+    'anchore/inline-scan:v0.6.0',
+    'anchore/inline-scan:v0.5.0',
+    'anchore/inline-scan:v0.5.1',
+]
+
+skip_reason = "Github Advisories not available in this version of Anchore Engine"
+
+
+class TestNonOsVulnerabilities:
+    """
+    Vulnerability output sample:
+
+    GHSA-grmf-4fq6-2r79        aubio-0.4.8                 Critical        0.4.9         CVE-2018-19800        https://github.com/advisories/GHSA-grmf-4fq6-2r79        python        github:python        /usr/local/lib64/python3.6/site-packages/aubio
+    GHSA-74xw-82v7-hmrm        python-dbusmock-0.15        High            0.15.1        CVE-2015-1326         https://github.com/advisories/GHSA-74xw-82v7-hmrm        python        github:python        /usr/local/lib/python3.6/site-packages/python-dbusmock
+    GHSA-7vvr-h4p5-m7fh        aubio-0.4.8                 High            0.4.9         CVE-2018-19801        https://github.com/advisories/GHSA-7vvr-h4p5-m7fh        python        github:python        /usr/local/lib64/python3.6/site-packages/aubio
+    GHSA-c6jq-h4jp-72pr        aubio-0.4.8                 High            0.4.9         CVE-2018-19802        https://github.com/advisories/GHSA-c6jq-h4jp-72pr        python        github:python        /usr/local/lib64/python3.6/site-packages/aubio
+    """
+
+    @pytest.fixture(scope='class')
+    def stdout(self, class_admin_call):
+        """
+        Fetch the output of non-os vulnerabilities in user-friendly format,
+        split on newlines. This fixture is used once for the whole class
+        """
+        out, err, code = class_admin_call(
+            ['image', 'vuln', 'alfredodeza/vulnerable', 'non-os']
+        )
+        return out.split('\n')
+
+    def item_count(self, item, lines):
+        return len([i for i in lines if item in i])
+
+    def test_plain_output(self, stdout):
+        assert len(stdout) == 6
+
+    def test_severity(self, stdout):
+        assert self.item_count(' Critical ', stdout) == 1
+        assert self.item_count(' High ', stdout) == 3
+
+    @pytest.mark.skipif(os.environ['PYTEST_CONTAINER'] in skip_versions, reason=skip_reason)
+    def test_github_com(self, stdout):
+        assert self.item_count('https://github.com/', stdout) == 4
+
+    @pytest.mark.skipif(os.environ['PYTEST_CONTAINER'] in skip_versions, reason=skip_reason)
+    def test_vulnerability_ids(self, stdout):
+        output = ''.join(stdout)
+        assert ' GHSA-grmf-4fq6-2r79' in output
+        assert ' GHSA-74xw-82v7-hmrm' in output
+        assert ' GHSA-7vvr-h4p5-m7fh' in output
+        assert ' GHSA-c6jq-h4jp-72pr' in output
+
+    @pytest.mark.skipif(os.environ['PYTEST_CONTAINER'] in skip_versions, reason=skip_reason)
+    def test_feed_group(self, stdout):
+        assert self.item_count('github:python', stdout) == 4
+
+    def test_type(self, stdout):
+        assert self.item_count(' python ', stdout) == 4
+
+    def test_packages(self, stdout):
+        output = ''.join(stdout)
+        assert self.item_count(' aubio-0.4.8 ', stdout) == 3
+        assert 'python-dbusmock-0.15' in output
+
+    @pytest.mark.skipif(os.environ['PYTEST_CONTAINER'] in skip_versions, reason=skip_reason)
+    def test_fixes(self, stdout):
+        output = ''.join(stdout)
+        assert self.item_count(' 0.4.9 ', stdout) == 3
+        assert '0.15.1' in output
+
+    def test_cve_refs(self, stdout):
+        output = ''.join(stdout)
+        assert ' CVE-2018-19800' in output
+        assert ' CVE-2015-1326 ' in output
+        assert ' CVE-2018-19801' in output
+        assert ' CVE-2018-19802' in output
+
+    def test_package_paths(self, stdout):
+        output = ''.join(stdout)
+        assert '/usr/local/lib64/python3.6/site-packages/aubio         ' in output
+        assert '/usr/local/lib/python3.6/site-packages/python-dbusmock ' in output
+        assert '/usr/local/lib64/python3.6/site-packages/aubio         ' in output
+        assert '/usr/local/lib64/python3.6/site-packages/aubio         ' in output


### PR DESCRIPTION
The following changes will add an image to a running Anchore Engine instance and then use the `anchore-cli` to verify its output. Adds a few tests, including one that ensures that https://github.com/anchore/anchore-cli/pull/78 will work.

There is a fix that needs to happen before pr #78 gets merged and it is described in the test that is getting skipped: the exception is eating the error, which should be handled. 

Eating up errors with bare excepts makes debugging this extremely hard, so that should get removed as well.