### PR TITLE
ci: pull ubi8 image to prevent CircleCi issues

### DIFF
--- a/scripts/ci/make/pipeline_tasks
+++ b/scripts/ci/make/pipeline_tasks
@@ -15,6 +15,9 @@ build() {
     local TEST_IMAGE_NAME="${2:?'required parameter'}"
 
     print_colorized WARN "building image ${TEST_IMAGE_NAME}"
+    # Prevents stale images in CircleCI, but creates another thing to update
+    # when this project moves to a different ubi version
+    docker pull registry.access.redhat.com/ubi8/ubi:8.1
     docker build --target anchore-cli-builder -t anchore-cli:builder -f ./Dockerfile .
     docker build --build-arg CLI_COMMIT="${COMMIT_SHA}" -t "${TEST_IMAGE_NAME}" -f ./Dockerfile .
     print_colorized WARN "successfully built image -- ${TEST_IMAGE_NAME}"


### PR DESCRIPTION
Stale images on CircleCI for ubi8 may cause issue when `sudo yum -y update` runs. By using the latest version, we ensure this deals with the most recent version preventing problems like the one below: 

```
Error: 
 Problem 1: cannot install the best update candidate for package python3-rpm-4.14.2-26.el8_1.x86_64
  - nothing provides libzstd.so.1()(64bit) needed by python3-rpm-4.14.2-37.el8.x86_64
 Problem 2: cannot install the best update candidate for package rpm-4.14.2-26.el8_1.x86_64
```