### PR TITLE
Clean up Makefile & add release functionality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,7 @@
 # Define YAML anchors
 .global_environment_vars: &global_environment_vars
   PROD_IMAGE_REPO: anchore/engine-cli
-  RELEASE_BRANCHES: 0.2 0.3 0.4 0.5 0.6 0.7
-  VERBOSE: true
+  LATEST_RELEASE_MAJOR_VERSION: 0.7
   TERM: xterm
 
 .attach_workspace: &attach_workspace
@@ -57,7 +56,7 @@
 # Start circleci configuration
 version: 2.1
 orbs:
-  anchore: anchore/anchore-engine@1.6.5
+  anchore: anchore/anchore-engine@1
 
 commands:
   run_tests:
@@ -268,6 +267,13 @@ workflows:
       - push_image:
           name: push_prod_image
           make_job: push-prod
+          context: dockerhub-prod
+          filters: *filter_semver_tags
+          requires:
+            - hold_for_approval
+      - push_image:
+          name: push_redhat_image
+          make_job: push-redhat
           context: dockerhub-prod
           filters: *filter_semver_tags
           requires:

--- a/Makefile
+++ b/Makefile
@@ -6,93 +6,98 @@
 ############################################################
 
 
-#### Docker Hub, git repos
-############################################################
-DEV_IMAGE_REPO := anchore/anchore-cli-dev
-PROD_IMAGE_REPO := anchore/anchore-cli
-TEST_HARNESS_REPO := https://github.com/anchore/test-infra.git
+# Make environment configuration
+#############################################
+
+SHELL := /usr/bin/env bash
+.DEFAULT_GOAL := help # Running make without args will run the help target
+.NOTPARALLEL: # Run make serially
+
+# Dockerhub image repo
+DEV_IMAGE_REPO = anchore/anchore-cli-dev
+
+# Shared CI scripts
+TEST_HARNESS_REPO = https://github.com/anchore/test-infra.git
+CI_CMD = anchore-ci/ci_harness
+
+# Python environment
+VENV = .venv
+ACTIVATE_VENV := . $(VENV)/bin/activate
+PYTHON := $(VENV)/bin/python3
+
+# Testing environment
+CLUSTER_CONFIG = tests/e2e/kind-config.yaml
+CLUSTER_NAME = e2e-testing
+K8S_VERSION = 1.15.7
+TEST_IMAGE_NAME = $(GIT_REPO):dev
 
 
 #### CircleCI environment variables
-# DOCKER_USER and DOCKER_PASS are declared in CircleCI contexts
-# LATEST_RELEASE_BRANCH is declared in CircleCI project env variables settings
+# exported variabled are made available to any script called by this Makefile
 ############################################################
-export VERBOSE ?= false
-export CI ?= false
-export DOCKER_PASS ?=
-export DOCKER_USER ?=
-export LATEST_RELEASE_BRANCH ?=
+
+# declared in .circleci/config.yaml
+export LATEST_RELEASE_MAJOR_VERSION ?=
 export PROD_IMAGE_REPO ?=
-export RELEASE_BRANCHES ?=
+
+# declared in CircleCI contexts
+export DOCKER_USER ?=
+export DOCKER_PASS ?=
+
+# declared in CircleCI project environment variables settings
+export REDHAT_PASS ?=
+export REDHAT_REGISTRY ?=
+
+# automatically set to 'true' by CircleCI runners
+export CI ?= false
 
 # Use $CIRCLE_BRANCH if it's set, otherwise use current HEAD branch
 GIT_BRANCH := $(shell echo $${CIRCLE_BRANCH:=$$(git rev-parse --abbrev-ref HEAD)})
 
 # Use $CIRCLE_PROJECT_REPONAME if it's set, otherwise the git project top level dir name
 GIT_REPO := $(shell echo $${CIRCLE_PROJECT_REPONAME:=$$(basename `git rev-parse --show-toplevel`)})
-TEST_IMAGE_NAME := $(GIT_REPO):dev
 
 # Use $CIRCLE_SHA if it's set, otherwise use SHA from HEAD
 COMMIT_SHA := $(shell echo $${CIRCLE_SHA:=$$(git rev-parse HEAD)})
 
-# Use $CIRCLE_TAG if it's set
-GIT_TAG ?= $(shell echo $${CIRCLE_TAG:=null})
-
-CLUSTER_NAME := e2e-testing
-
-
-# Environment configuration for make
-############################################################
-VENV := venv
-ACTIVATE_VENV := . $(VENV)/bin/activate
-PYTHON := $(VENV)/bin/python3
-CLUSTER_CONFIG := tests/e2e/kind-config.yaml
-K8S_VERSION := 1.15.7
-
-# Running make will invoke the help target
-.DEFAULT_GOAL := help
-
-# Run make serially. Note that recursively invoked make will still
-# run recipes in parallel (unless they also contain .NOTPARALLEL)
-.NOTPARALLEL:
-
-CI_CMD := anchore-ci/ci_harness
+# Use $CIRCLE_TAG if it's set, otherwise set to null
+GIT_TAG := $(shell echo $${CIRCLE_TAG:=null})
 
 
 #### Make targets
 ############################################################
 
-.PHONY: all venv install install-dev lint build
-.PHONY: test test-unit test-functional
-.PHONY: setup-and-test-e2e test-e2e
-.PHONY: push-dev push-rc push-prod push-rebuild
-.PHONY: clean clean-noprompt clean-venv clean-tox clean-dist clean-image clean-py-cache
-.PHONY: printvars help
+.PHONY: ci build install install-dev
+.PHONY: lint clean clean-all test
+.PHONY: test-unit test-functional setup-and-test-e2e test-e2e
+.PHONY: push-dev push-rc push-prod push-rebuild push-redhat
+.PHONY: cluster-up cluster-down 
+.PHONY: setup-test-infra venv printvars help
 
-all: VERBOSE := true ## Run Anchore CLI full CI pipeline locally (lint, build, test, push)
-all: lint build test push-dev
+ci: lint build test ## Run full CI pipeline, locally
 
-anchore-ci: ## Fetch test artifacts for local CI
-	rm -rf /tmp/test-infra; git clone $(TEST_HARNESS_REPO) /tmp/test-infra
-	mv ./anchore-ci ./anchore-ci-`date +%F-%H-%M-%S`; mv /tmp/test-infra/anchore-ci .
-
-venv: $(VENV)/bin/activate ## Set up a virtual environment
-$(VENV)/bin/activate:
-	python3 -m venv $(VENV)
+build: Dockerfile anchore-ci venv ## Build dev Anchore CLI Docker image
+	@$(CI_CMD) scripts/ci/build "$(COMMIT_SHA)" "$(GIT_REPO)" "$(TEST_IMAGE_NAME)"
 
 install: venv setup.py requirements.txt ## Install to virtual environment
-	@$(ACTIVATE_VENV) && $(PYTHON) setup.py install
+	$(ACTIVATE_VENV) && $(PYTHON) setup.py install
 
 install-dev: venv setup.py requirements.txt ## Install to virtual environment in editable mode
-	@$(ACTIVATE_VENV) && $(PYTHON) -m pip install --editable .
+	$(ACTIVATE_VENV) && $(PYTHON) -m pip install --editable .
 
 lint: venv anchore-ci ## Lint code (currently using flake8)
 	@$(ACTIVATE_VENV) && $(CI_CMD) lint
 
-# Local CI script
-build: Dockerfile anchore-ci venv ## Build dev Anchore CLI Docker image
-	@$(CI_CMD) scripts/ci/build "$(COMMIT_SHA)" "$(GIT_REPO)" "$(TEST_IMAGE_NAME)"
+clean: ## Clean everything (with prompts)
+	@$(CI_CMD) clean "$(VENV)" "$(TEST_IMAGE_NAME)"
 
+clean-all: export NOPROMPT = true
+clean-all: ## Clean everything (without prompts)
+	@$(CI_CMD) clean "$(VENV)" "$(TEST_IMAGE_NAME)" $(NOPROMPT)
+
+
+# Testing targets
+#####################
 test: ## Run all tests: unit, functional, and e2e
 	@$(MAKE) test-unit
 	@$(MAKE) test-functional
@@ -104,17 +109,6 @@ test-unit: anchore-ci venv ## Run unit tests (tox)
 test-functional: anchore-ci venv ## Run functional tests (tox)
 	@$(ACTIVATE_VENV) && $(CI_CMD) test-functional tests/functional/tox.ini
 
-install-cluster-deps: anchore-ci venv ## Install kind, helm, and kubectl (unless installed)
-	$(CI_CMD) install-cluster-deps "$(VENV)"
-
-cluster-up: anchore-ci venv ## Stand up/start kind cluster
-	@$(MAKE) install-cluster-deps
-	$(ACTIVATE_VENV) && $(CI_CMD) cluster-up "$(CLUSTER_NAME)" "$(CLUSTER_CONFIG)" "$(K8S_VERSION)"
-
-cluster-down: anchore-ci venv ## Tear down/stop kind cluster
-	@$(MAKE) install-cluster-deps
-	$(ACTIVATE_VENV) && $(CI_CMD) cluster-down "$(CLUSTER_NAME)"
-
 setup-e2e-tests: anchore-ci venv ## Start kind cluster and set up end to end tests
 	@$(MAKE) cluster-up
 	@$(ACTIVATE_VENV) && $(CI_CMD) setup-e2e-tests "$(COMMIT_SHA)" "$(DEV_IMAGE_REPO)" "$(GIT_TAG)" "$(TEST_IMAGE_NAME)"
@@ -122,12 +116,14 @@ setup-e2e-tests: anchore-ci venv ## Start kind cluster and set up end to end tes
 test-e2e: anchore-ci venv ## Run end to end tests (assuming cluster is running and set up has been run)
 	@$(ACTIVATE_VENV) && $(CI_CMD) e2e-tests
 
-# Local CI scripts (setup-e2e-tests and e2e-tests)
 setup-and-test-e2e: anchore-ci venv ## Set up and run end to end tests
 	@$(MAKE) setup-e2e-tests
 	@$(MAKE) test-e2e
 	@$(MAKE) cluster-down
 
+
+# Release targets
+######################
 push-dev: anchore-ci ## Push dev Anchore CLI Docker image to Docker Hub
 	@$(CI_CMD) push-dev-image "$(COMMIT_SHA)" "$(DEV_IMAGE_REPO)" "$(GIT_BRANCH)" "$(TEST_IMAGE_NAME)"
 
@@ -137,33 +133,39 @@ push-rc: anchore-ci ## (Not available outside of CI) Push RC Anchore CLI Docker 
 push-prod: anchore-ci ## (Not available outside of CI) Push release Anchore CLI Docker image to Docker Hub
 	@$(CI_CMD) push-prod-image-release "$(DEV_IMAGE_REPO)" "$(GIT_BRANCH)" "$(GIT_TAG)"
 
+push-redhat: setup-test-infra ## (Not available outside of CI) Push prod Anchore Engine docker image to RedHat Connect
+	@$(CI_CMD) push-redhat-image "$(GIT_TAG)"
+
 push-rebuild: anchore-ci ## (Not available outside of CI) Rebuild and push prod Anchore CLI docker image to Docker Hub
 	@$(CI_CMD) push-prod-image-rebuild "$(DEV_IMAGE_REPO)" "$(GIT_BRANCH)" "$(GIT_TAG)"
 
-clean: ## Clean everything (with prompts)
-	@$(CI_CMD) clean "$(VENV)" "$(TEST_IMAGE_NAME)"
 
-clean-noprompt: ## Clean everything (without prompts)
-	@$(CI_CMD) clean-noprompt "$(VENV)" "$(TEST_IMAGE_NAME)"
+# Helper targets
+####################
+cluster-up: anchore-ci venv ## Stand up/start kind cluster
+	@$(CI_CMD) install-cluster-deps "$(VENV)"
+	@$(ACTIVATE_VENV) && $(CI_CMD) cluster-up "$(CLUSTER_NAME)" "$(CLUSTER_CONFIG)" "$(K8S_VERSION)"
 
-clean-venv: ## Delete virtual environment
-	@$(CI_CMD) clean-venv "$(VENV)" "$(TEST_IMAGE_NAME)"
+cluster-down: anchore-ci venv ## Tear down/stop kind cluster
+	@$(CI_CMD) install-cluster-deps "$(VENV)"
+	@$(ACTIVATE_VENV) && $(CI_CMD) cluster-down "$(CLUSTER_NAME)"
 
-clean-dist: ## Delete build and dist data
-	@$(CI_CMD) clean-dist
+setup-test-infra: /tmp/test-infra ## Fetch anchore/test-infra repo for CI scripts
+	cd /tmp/test-infra && git pull
+	@$(MAKE) anchore-ci
+anchore-ci: /tmp/test-infra/anchore-ci
+	rm -rf ./anchore-ci; cp -R /tmp/test-infra/anchore-ci .
+/tmp/test-infra/anchore-ci: /tmp/test-infra
+/tmp/test-infra:
+	git clone $(TEST_HARNESS_REPO) /tmp/test-infra
 
-clean-tox: ## Delete .tox directory
-	@$(CI_CMD) clean-tox
-
-clean-image: ## Delete Docker test image
-	@$(CI_CMD) clean-image "$(TEST_IMAGE_NAME)"
-
-clean-py-cache: ## Delete local python cache files
-	@$(CI_CMD) clean-py-cache
+venv: $(VENV)/bin/activate ## Set up a virtual environment
+$(VENV)/bin/activate:
+	python3 -m venv $(VENV)
 
 printvars: ## Print make variables
 	@$(foreach V,$(sort $(.VARIABLES)),$(if $(filter-out environment% default automatic,$(origin $V)),$(warning $V=$($V) ($(value $V)))))
 
-help: ## Show this usage message
+help:
 	@printf "\n%s\n\n" "usage: make <target>"
-	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[0;36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[0;36m%-30s\033[0m %s\n", $$1, $$2}' | rev

--- a/Makefile
+++ b/Makefile
@@ -168,4 +168,4 @@ printvars: ## Print make variables
 
 help:
 	@printf "\n%s\n\n" "usage: make <target>"
-	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[0;36m%-30s\033[0m %s\n", $$1, $$2}' | rev
+	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[0;36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
Restructured the Makefile for better readability. Also added a push-redhat-image job as part of the semver tag workflow.

I recommend not looking at the Makefile diff because I restructured the entire file so it's hard to read. The only actual changes to the Makefile are to the following targets:
```
anchore-ci -> setup-test-infra
clean* -> compacted to clean & clean-all
push-redhat *new*
```