### PR TITLE
Add webhook test capability

### DIFF
--- a/anchorecli/cli/system.py
+++ b/anchorecli/cli/system.py
@@ -486,3 +486,51 @@ def delete_data(feed, group=None):
             ecode = 2
 
     anchorecli.cli.utils.doexit(ecode)
+
+
+@system.group(name="webhook", short_help="For testing webhooks")
+def webhook():
+    pass
+
+
+@webhook.command(name="test", short_help="Test that a given webhook works")
+@click.argument("webhook_type", nargs=1, required=False)
+@click.option(
+    "--ntype",
+    default="tag_update",
+    help="The type of notification to send via the given webhook_type",
+    required=False,
+)
+def test_webhook(webhook_type, ntype):
+    """
+    Call the Test Webhook Endpoint on Anchore Engine
+    :param webhook_type: the type of webhook to send a test notification for
+    """
+
+    ecode = 0
+
+    if not webhook_type:
+        webhook_type = "general"
+
+    try:
+        _logger.debug(
+            "Testing Webhook delivery for type '{}', notification_type '{}'".format(
+                webhook_type, ntype
+            )
+        )
+        ret = anchorecli.clients.apiexternal.test_webhook(config, webhook_type, ntype)
+        ecode = anchorecli.cli.utils.get_ecode(ret)
+        if ret["success"]:
+            print(
+                anchorecli.cli.utils.format_output(
+                    config, "test_webhook", {}, ret["payload"]
+                )
+            )
+        else:
+            raise Exception(json.dumps(ret["error"], indent=4))
+    except Exception as err:
+        print(anchorecli.cli.utils.format_error_output(config, "test_webhook", {}, err))
+        if not ecode:
+            ecode = 2
+
+    anchorecli.cli.utils.doexit(ecode)

--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -1158,6 +1158,16 @@ def format_output(config, op, params, payload):
                 ]
                 t.add_row(row)
             ret = t.get_string(sortby="Transition Date", reversesort=True) + "\n"
+        elif (
+            op in ["delete_system_service", "test_webhook"]
+            or re.match(".*_delete$", op)
+            or re.match(".*_activate$", op)
+            or re.match(".*_deactivate$", op)
+            or re.match(".*_enable$", op)
+            or re.match(".*_disable$", op)
+        ):
+            # NOTE this should always be the last in the if/elif conditional
+            ret = "Success"
         else:
             raise Exception("no output handler for this operation ({})".format(op))
     except Exception as err:

--- a/anchorecli/clients/apiexternal.py
+++ b/anchorecli/clients/apiexternal.py
@@ -2424,3 +2424,30 @@ def add_transition_rule(
         raise err
 
     return ret
+
+
+def test_webhook(config, webhook_type="general", notification_type="tag_update"):
+    """
+    Calls the API to test whether or not a webhook is correctly configured
+
+    :param config: the configuration to retrieve request metadata from
+    :param webhook_type: the type of webhook to test (defaults to general)
+    """
+    user = config["user"]
+    pw = config["pass"]
+    base_url = config["url"]
+
+    base_url = re.sub("/$", "", base_url)
+    url = "/".join([base_url, "system", "webhooks", webhook_type, "test"])
+
+    url = url + "?notification_type={}".format(notification_type)
+
+    set_account_header(config)
+
+    _logger.debug("POST url=%s", str(url))
+    r = requests.post(
+        url, auth=(user, pw), verify=config["ssl_verify"], headers=header_overrides
+    )
+    ret = anchorecli.clients.common.make_client_result(r, raw=False)
+
+    return ret


### PR DESCRIPTION
This is the sister PR for the change in the [engine](https://github.com/anchore/anchore-engine/pull/570).

Add ability to test webhook delivery based on webhook_type:
```zsh
(venv) samdacanay@samsanchorembp anchore-cli % docker run -it --rm --net=host anchore-cli:dev anchore-cli system webhook test
Success
```