### PR TITLE
Removed wait for disabled groups in feed

### DIFF
--- a/anchorecli/cli/system.py
+++ b/anchorecli/cli/system.py
@@ -242,7 +242,9 @@ def wait(timeout, interval, feedsready, servicesready):
                                             group_record.get("name", None),
                                             group_record.get("last_sync", None),
                                         )
-                                        if group_record.get("last_sync", None):
+                                        if group_record.get(
+                                            "last_sync", None
+                                        ) or not group_record.get("enabled", None):
                                             all_groups_synced = True
                                         else:
                                             all_groups_synced = False

--- a/anchorecli/cli/system.py
+++ b/anchorecli/cli/system.py
@@ -11,6 +11,10 @@ config = {}
 _logger = logging.getLogger(__name__)
 
 
+class WaitOnDisabledFeed(Exception):
+    pass
+
+
 @click.group(name="system", short_help="System operations")
 @click.pass_context
 @click.pass_obj
@@ -234,6 +238,13 @@ def wait(timeout, interval, feedsready, servicesready):
                                 feed_record.get("last_full_sync"),
                             )
                             if feed_record.get("name", None) in all_up:
+                                if not feed_record.get("enabled"):
+                                    raise WaitOnDisabledFeed(
+                                        "Requesting wait for disabled feed: {}".format(
+                                            feed_record.get("name")
+                                        )
+                                    )
+
                                 if feed_record.get("last_full_sync", None):
                                     all_groups_synced = False
                                     for group_record in feed_record.get("groups", []):
@@ -257,6 +268,8 @@ def wait(timeout, interval, feedsready, servicesready):
                             break
                         else:
                             _logger.debug("some feeds not yet synced %s", all_up)
+                except WaitOnDisabledFeed as err:
+                    raise err
                 except Exception as err:
                     print("service feeds list failed {}".format(err))
                 time.sleep(interval)

--- a/anchorecli/cli/system.py
+++ b/anchorecli/cli/system.py
@@ -11,7 +11,7 @@ config = {}
 _logger = logging.getLogger(__name__)
 
 
-class WaitOnDisabledFeed(Exception):
+class WaitOnDisabledFeedError(Exception):
     pass
 
 
@@ -239,7 +239,7 @@ def wait(timeout, interval, feedsready, servicesready):
                             )
                             if feed_record.get("name", None) in all_up:
                                 if not feed_record.get("enabled"):
-                                    raise WaitOnDisabledFeed(
+                                    raise WaitOnDisabledFeedError(
                                         "Requesting wait for disabled feed: {}".format(
                                             feed_record.get("name")
                                         )
@@ -268,7 +268,7 @@ def wait(timeout, interval, feedsready, servicesready):
                             break
                         else:
                             _logger.debug("some feeds not yet synced %s", all_up)
-                except WaitOnDisabledFeed as err:
+                except WaitOnDisabledFeedError as err:
                     raise err
                 except Exception as err:
                     print("service feeds list failed {}".format(err))

--- a/tests/unit/cli/test_system.py
+++ b/tests/unit/cli/test_system.py
@@ -9,7 +9,28 @@ import anchorecli.clients.apiexternal
 @pytest.fixture
 def make_feed_response():
     def _make_feed_response(additional_vuln_group_records=[]):
-        return {
+        groups = [
+            {
+                "created_at": "2020-03-27T22:48:57Z",
+                "enabled": True,
+                "last_sync": "2020-12-23T19:34:06Z",
+                "name": "alpine:3.7",
+                "record_count": 1412,
+                "updated_at": "2020-12-23T19:34:07Z",
+            },
+            {
+                "created_at": "2020-03-27T22:48:57Z",
+                "enabled": True,
+                "last_sync": "2020-12-23T19:33:29Z",
+                "name": "centos:5",
+                "record_count": 1347,
+                "updated_at": "2020-12-23T19:34:06Z",
+            },
+        ]
+
+        groups += additional_vuln_group_records
+
+        response = {
             "success": True,
             "httpcode": 200,
             "payload": [
@@ -18,28 +39,12 @@ def make_feed_response():
                     "enabled": True,
                     "last_full_sync": "2020-12-23T19:34:29Z",
                     "updated_at": "2020-12-23T19:34:29Z",
-                    "groups": [
-                        {
-                            "created_at": "2020-03-27T22:48:57Z",
-                            "enabled": True,
-                            "last_sync": "2020-12-23T19:34:06Z",
-                            "name": "alpine:3.7",
-                            "record_count": 1412,
-                            "updated_at": "2020-12-23T19:34:07Z",
-                        },
-                        {
-                            "created_at": "2020-03-27T22:48:57Z",
-                            "enabled": True,
-                            "last_sync": "2020-12-23T19:33:29Z",
-                            "name": "centos:5",
-                            "record_count": 1347,
-                            "updated_at": "2020-12-23T19:34:06Z",
-                        },
-                        *additional_vuln_group_records,
-                    ],
+                    "groups": groups,
                 }
             ],
         }
+
+        return response
 
     return _make_feed_response
 

--- a/tests/unit/cli/test_system.py
+++ b/tests/unit/cli/test_system.py
@@ -1,1 +1,89 @@
+import pytest
 from anchorecli.cli import system
+from click.testing import CliRunner
+import anchorecli.cli.utils
+import anchorecli.clients.apiexternal
+
+
+# feed response generator that can conditionally add group members in order to parameterize tests
+@pytest.fixture
+def make_feed_response():
+    def _make_feed_response(additional_vuln_group_records=[]):
+        return {
+            "success": True,
+            "httpcode": 200,
+            "payload": [
+                {
+                    "name": "vulnerabilities",
+                    "enabled": True,
+                    "last_full_sync": "2020-12-23T19:34:29Z",
+                    "updated_at": "2020-12-23T19:34:29Z",
+                    "groups": [
+                        {
+                            "created_at": "2020-03-27T22:48:57Z",
+                            "enabled": True,
+                            "last_sync": "2020-12-23T19:34:06Z",
+                            "name": "alpine:3.7",
+                            "record_count": 1412,
+                            "updated_at": "2020-12-23T19:34:07Z",
+                        },
+                        {
+                            "created_at": "2020-03-27T22:48:57Z",
+                            "enabled": True,
+                            "last_sync": "2020-12-23T19:33:29Z",
+                            "name": "centos:5",
+                            "record_count": 1347,
+                            "updated_at": "2020-12-23T19:34:06Z",
+                        },
+                        *additional_vuln_group_records,
+                    ],
+                }
+            ],
+        }
+
+    return _make_feed_response
+
+
+feed_wait_tests = [
+    {"additional_vuln_group_records": [], "expect_success": True},
+    {
+        "additional_vuln_group_records": [
+            {"name": "centos:7", "enabled": True, "last_sync": None, "record_count": 0}
+        ],
+        "expect_success": False,
+    },
+    {
+        "additional_vuln_group_records": [
+            {"name": "centos:7", "enabled": False, "last_sync": None, "record_count": 0}
+        ],
+        "expect_success": True,
+    },
+]
+
+
+@pytest.mark.parametrize("test_context", feed_wait_tests)
+def test_wait_for_feeds(monkeypatch, make_feed_response, test_context):
+    monkeypatch.setattr(
+        system, "config", {"url": "http://localhost:8228", "jsonmode": False}
+    )
+    monkeypatch.setattr(anchorecli.cli.utils, "check_access", lambda x: {})
+    monkeypatch.setattr(
+        anchorecli.clients.apiexternal,
+        "system_status",
+        lambda x: {"success": True, "httpcode": 200},
+    )
+    monkeypatch.setattr(
+        anchorecli.clients.apiexternal,
+        "system_feeds_list",
+        lambda x: make_feed_response(test_context["additional_vuln_group_records"]),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(system.wait, ["--servicesready", "", "--timeout", "5"])
+
+    if test_context["expect_success"]:
+        assert result.exit_code == 0
+        assert "Feed sync: Success." in result.output
+    else:
+        assert result.exit_code == 2
+        assert "Error: timed out" in result.output

--- a/tests/unit/cli/test_system.py
+++ b/tests/unit/cli/test_system.py
@@ -112,3 +112,15 @@ def test_wait_for_disabled_feed(monkeypatch, make_feed_response, patch_for_feeds
     result = runner.invoke(system.wait, ["--servicesready", "", "--timeout", "5"])
     assert result.exit_code == 2
     assert "Error: Requesting wait for disabled feed: vulnerabilities" in result.output
+
+
+def test_wait_for_enabled_feed(monkeypatch, make_feed_response, patch_for_feeds_wait):
+    monkeypatch.setattr(
+        anchorecli.clients.apiexternal,
+        "system_feeds_list",
+        lambda x: make_feed_response(),
+    )
+    runner = CliRunner()
+    result = runner.invoke(system.wait, ["--servicesready", "", "--timeout", "5"])
+    assert result.exit_code == 0
+    assert "Feed sync: Success" in result.output


### PR DESCRIPTION
Fixes #138  by checking if group record is disabled before determining if the wait command should wait for the group to sync 

Signed-off-by: Zane Burstein <zane.burstein@anchore.com>