### PR TITLE
Bump PyYAML version to 5.4.1 from 5.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Click==7.0
 prettytable==0.7.2
 python-dateutil==2.8.1
-PyYAML==5.3.1
+PyYAML==5.4.1
 requests==2.23.0
 six==1.14.0
 urllib3==1.25.9


### PR DESCRIPTION
Change requirements.txt to include 5.4.1 which will address the current CVE against PyYAML.
**CVE-2020-14343**
closes: #155 
Signed-off-by: Toure Dunnon <toure.dunnon@anchore.com>