### PR TITLE
Added new transition rule attributes to outputs

### DIFF
--- a/anchorecli/cli/utils.py
+++ b/anchorecli/cli/utils.py
@@ -1135,6 +1135,11 @@ def format_output(config, op, params, payload):
                 "Registry",
                 "Repository",
                 "Tag",
+                "Max Images",
+                "Registry Exclude",
+                "Repo Exclude",
+                "Tag Exclude",
+                "Exclude Exp Days",
                 "Last Updated",
             ]
             t = plain_column_table(header)
@@ -1150,6 +1155,11 @@ def format_output(config, op, params, payload):
                     str(record["selector"]["registry"]),
                     str(record["selector"]["repository"]),
                     str(record["selector"]["tag"]),
+                    str(record["max_images_per_account"]),
+                    str(record["exclude"]["selector"]["registry"]),
+                    str(record["exclude"]["selector"]["repository"]),
+                    str(record["exclude"]["selector"]["tag"]),
+                    str(record["exclude"]["expiration_days"]),
                     str(record["last_updated"]),
                 ]
                 t.add_row(row)


### PR DESCRIPTION
Fixes #161 

Sample output: 
```
Rule Id                                 Global        Transition        Analysis Age (Days)        Tag Versions Newer        Registry         Repository        Tag        Max Images        Registry Exclude        Repo Exclude        Tag Exclude        Exclude Exp Days        Last Updated
a6e3dbfc260a4cf7b27a33b50f8a742f        True          archive           90                         0                         *                *                 *          10                                                                               -1                      2021-01-27T19:02:25Z
0d13792874504a8e8dd931b486493260        False         archive           90                         0                         docker.io        centos            *          None              docker.io               centos              latest             5                       2021-01-27T18:55:40Z
0944ecd5313a4640a70781a2279eb976        False         archive           90                         0                         docker.io        centos            *          None              docker.io               centos              latest             5                       2021-01-27T17:48:06Z
```

Signed-off-by: Zane Burstein <zane.burstein@anchore.com>