### PR TITLE
Updates urllib3 version and tox adjustment

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest
+memory_profiler
+coverage==5.3.1
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ Click==7.0
 prettytable==0.7.2
 python-dateutil==2.8.1
 PyYAML==5.4.1
-requests==2.23.0
+requests==2.26.0
 six==1.14.0
-urllib3==1.25.9
+urllib3==1.26.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,19 @@
 [tox]
-envlist = py27, py35, py36, py37, flake8
+envlist = py27, py35, py36, py37, py38, py39, flake8
 skip_missing_interpreters = true
 
 [testenv]
 deps=
-  pytest
+    -rrequirements.txt
+    -rrequirements-test.txt
 
-commands=pytest --junitxml=.tox/results/tox/junit-{envname}.xml {posargs:tests} --ignore=tests/functional
+passenv=ANCHORE_* DOCKER_* NO_PROXY TEST_VULNERABILITIES_PROVIDER
+
+commands=
+    coverage erase
+    coverage run -m pytest -vv --junitxml=.tox/results/tox/junit-{envname}.xml {posargs}
+    - coverage report --include=*anchorecli* --omit=*tests*
+    - coverage html --include=*anchorecli* --omit=*tests*
 
 [testenv:flake8]
 deps=flake8


### PR DESCRIPTION
An issue was found via dependabot alerting us the
urllib3 version need to be bumped.  When changing
version, it required the requests library version
to change as well for compatibility.

This patch updates the tox file [testenv] to provide
additional Python versions and adds code coverage found
in engine and enterprise.

Fixes #ENTERPRISE-562

Signed-off-by: Ryan Brady <ryan.brady@anchore.com>