### PR TITLE
update UBI base image to v8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
 ARG BASE_IMAGE=ubi8/ubi
-ARG BASE_TAG=8.4
+ARG BASE_TAG=8.5
 
 #### Start first stage
 #### Anchore wheels, binary dependencies, etc. are staged to /build_output for second stage


### PR DESCRIPTION
Updating to the latest version to ubi8 to fix the build errors that occurred during yum update

This should not be a significant change as ubi 8.5 is basically the same as using ubi 8.4 + yum update.

Signed-off-by: Brady Todhunter <bradyt@anchore.com>